### PR TITLE
fix(bilibili_downloader): 移除音频转码步骤并更改输出格式

### DIFF
--- a/backend/app/downloaders/bilibili_downloader.py
+++ b/backend/app/downloaders/bilibili_downloader.py
@@ -31,13 +31,6 @@ class BilibiliDownloader(Downloader, ABC):
         ydl_opts = {
             'format': 'bestaudio[ext=m4a]/bestaudio/best',
             'outtmpl': output_path,
-            'postprocessors': [
-                {
-                    'key': 'FFmpegExtractAudio',
-                    'preferredcodec': 'mp3',
-                    'preferredquality': '64',
-                }
-            ],
             'noplaylist': True,
             'quiet': False,
         }
@@ -48,7 +41,7 @@ class BilibiliDownloader(Downloader, ABC):
             title = info.get("title")
             duration = info.get("duration", 0)
             cover_url = info.get("thumbnail")
-            audio_path = os.path.join(output_dir, f"{video_id}.mp3")
+            audio_path = os.path.join(output_dir, f"{video_id}.m4a")
 
         return AudioDownloadResult(
             file_path=audio_path,


### PR DESCRIPTION
- 移除了 ydl_opts 中的 postprocessors 设置，取消了将音频转码为 mp3 的步骤
- 将输出音频文件的扩展名从 mp3 改为 m4a