### PR TITLE
feat(downloaders): 更新 Bilibili 和 YouTube 下载器的视频质量选择

### DIFF
--- a/backend/app/downloaders/bilibili_downloader.py
+++ b/backend/app/downloaders/bilibili_downloader.py
@@ -69,7 +69,7 @@ class BilibiliDownloader(Downloader, ABC):
         output_path = os.path.join(output_dir, "%(id)s.%(ext)s")
 
         ydl_opts = {
-            'format': 'bv*[ext=mp4]/bestvideo+bestaudio/best',
+            'format': 'best[height<=480][ext=mp4]/best[height<=480]/best',
             'outtmpl': output_path,
             'noplaylist': True,
             'quiet': False,

--- a/backend/app/downloaders/youtube_downloader.py
+++ b/backend/app/downloaders/youtube_downloader.py
@@ -30,7 +30,7 @@ class YoutubeDownloader(Downloader, ABC):
         output_path = os.path.join(output_dir, "%(id)s.%(ext)s")
 
         ydl_opts = {
-            'format': 'bestaudio[ext=m4a]/bestaudio/best',
+            'format': 'best[height<=480][ext=mp4]/best[height<=480]/best',
             'outtmpl': output_path,
             'noplaylist': True,
             'quiet': False,


### PR DESCRIPTION
- Bilibili 下载器：将视频格式选择更改为优先下载 MP4 格式，且分辨率不超过 480p
- YouTube 下载器：将视频格式选择更改为优先下载 MP4 格式，且分辨率不超过 480p