### PR TITLE
feat:将transcriber作为环境变量配置并增加了 MLX‑Whisper 转录器，提升 macOS 平台转录性能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ QWEN_MODEL=
 MODEl_PROVIDER= #如果不是openai 请修改 deepseek/qwen
 # FFMPEG 配置
 FFMPEG_BIN_PATH=
+
+# transcriber 相关配置
+TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou
+WHISPER_MODEL_SIZE=base

--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,5 @@ MODEl_PROVIDER= #如果不是openai 请修改 deepseek/qwen
 FFMPEG_BIN_PATH=
 
 # transcriber 相关配置
-TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou
+TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou/mlx-whisper(仅Apple平台)
 WHISPER_MODEL_SIZE=base

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,7 @@ QWEN_API_KEY=
 QWEN_API_BASE_URL=
 QWEN_MODEL=
 MODEl_PROVIDER= #如果不是openai 请修改 deepseek/qwen
+
+# transcriber 相关配置
+TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou
+WHISPER_MODEL_SIZE=base

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -18,7 +18,7 @@ from app.models.notes_model import AudioDownloadResult
 from app.enmus.note_enums import DownloadQuality
 from app.models.transcriber_model import TranscriptResult
 from app.transcriber.base import Transcriber
-from app.transcriber.transcriber_provider import get_transcriber
+from app.transcriber.transcriber_provider import get_transcriber,_transcribers
 from app.transcriber.whisper import WhisperTranscriber
 import re
 
@@ -89,9 +89,9 @@ class NoteGenerator:
         :param transcriber: 选择的转义器
         :return:
         '''
-        if self.transcriber_type == 'fast-whisper':
-            logger.info("使用Whisper")
-            return get_transcriber(transcriber_type='fast-whisper')
+        if self.transcriber_type in _transcribers.keys():
+            logger.info(f"使用{self.transcriber_type}转义器")
+            return get_transcriber(transcriber_type=self.transcriber_type)
         else:
             logger.warning("不支持的转义器")
             raise ValueError(f"不支持的转义器：{self.transcriber}")

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -43,7 +43,7 @@ class NoteGenerator:
     def __init__(self):
         self.model_size: str = 'base'
         self.device: Union[str, None] = None
-        self.transcriber_type = 'fast-whisper'
+        self.transcriber_type = os.getenv('TRANSCRIBER_TYPE','fast-whisper')
         self.transcriber = self.get_transcriber()
         # TODO 需要更换为可调节
 
@@ -91,7 +91,7 @@ class NoteGenerator:
         '''
         if self.transcriber_type == 'fast-whisper':
             logger.info("使用Whisper")
-            return get_transcriber()
+            return get_transcriber(transcriber_type='fast-whisper')
         else:
             logger.warning("不支持的转义器")
             raise ValueError(f"不支持的转义器：{self.transcriber}")

--- a/backend/app/transcriber/mlx_whisper_transcriber.py
+++ b/backend/app/transcriber/mlx_whisper_transcriber.py
@@ -1,0 +1,88 @@
+import mlx_whisper
+from pathlib import Path
+import os
+import platform
+from huggingface_hub import snapshot_download
+
+from app.decorators.timeit import timeit
+from app.models.transcriber_model import TranscriptSegment, TranscriptResult
+from app.transcriber.base import Transcriber
+from app.utils.logger import get_logger
+from app.utils.path_helper import get_model_dir
+from events import transcription_finished
+
+logger = get_logger(__name__)
+
+class MLXWhisperTranscriber(Transcriber):
+    def __init__(
+            self,
+            model_size: str = "base"
+    ):
+        # 检查平台
+        if platform.system() != "Darwin":
+            raise RuntimeError("MLX Whisper 仅支持 Apple 平台")
+            
+        # 检查环境变量
+        if os.environ.get("TRANSCRIBER_TYPE") != "mlx-whisper":
+            raise RuntimeError("必须设置环境变量 TRANSCRIBER_TYPE=mlx-whisper 才能使用 MLX Whisper")
+            
+        self.model_size = model_size
+        self.model_name = f"mlx-community/whisper-{model_size}"
+        self.model_path = None
+        
+        # 设置模型路径
+        model_dir = get_model_dir("mlx-whisper")
+        self.model_path = os.path.join(model_dir, self.model_name)
+        # 检查并下载模型
+        if not Path(self.model_path).exists():
+            logger.info(f"模型 {self.model_name} 不存在，开始下载...")
+            snapshot_download(
+                self.model_name,
+                local_dir=self.model_path,
+                local_dir_use_symlinks=False,
+            )
+            logger.info("模型下载完成")
+        
+        logger.info(f"初始化 MLX Whisper 转录器，模型：{self.model_name}")
+
+    @timeit
+    def transcript(self, file_path: str) -> TranscriptResult:
+        try:
+            # 使用 MLX Whisper 进行转录
+            result = mlx_whisper.transcribe(
+                file_path,
+                path_or_hf_repo=f"{self.model_name}"
+            )
+            
+            # 转换为标准格式
+            segments = []
+            full_text = ""
+            
+            for segment in result["segments"]:
+                text = segment["text"].strip()
+                full_text += text + " "
+                segments.append(TranscriptSegment(
+                    start=segment["start"],
+                    end=segment["end"],
+                    text=text
+                ))
+            
+            transcript_result = TranscriptResult(
+                language=result.get("language", "unknown"),
+                full_text=full_text.strip(),
+                segments=segments,
+                raw=result
+            )
+            
+            self.on_finish(file_path, transcript_result)
+            return transcript_result
+            
+        except Exception as e:
+            logger.error(f"MLX Whisper 转写失败：{e}")
+            raise e
+
+    def on_finish(self, video_path: str, result: TranscriptResult) -> None:
+        logger.info("MLX Whisper 转写完成")
+        transcription_finished.send({
+            "file_path": video_path,
+        }) 

--- a/backend/app/transcriber/transcriber_provider.py
+++ b/backend/app/transcriber/transcriber_provider.py
@@ -1,3 +1,5 @@
+import os
+
 from app.transcriber.whisper import WhisperTranscriber
 from app.transcriber.bcut import BcutTranscriber
 from app.transcriber.kuaishou import KuaishouTranscriber
@@ -49,12 +51,12 @@ def get_kuaishou_transcriber():
             raise
     return _transcribers['kuaishou']
 
-def get_transcriber(transcriber_type="whisper", model_size="base", device="cuda"):
+def get_transcriber(transcriber_type="fast-whisper", model_size="base", device="cuda"):
     """
     获取指定类型的转录器实例
     
     参数:
-        transcriber_type: 转录器类型，支持 "whisper", "bcut", "kuaishou"
+        transcriber_type: 转录器类型，支持 "fast-whisper", "bcut", "kuaishou"
         model_size: 模型大小，whisper 特有参数
         device: 设备类型，whisper 特有参数
     
@@ -62,13 +64,14 @@ def get_transcriber(transcriber_type="whisper", model_size="base", device="cuda"
         对应类型的转录器实例
     """
     logger.info(f'获取转录器，类型: {transcriber_type}')
-    
-    if transcriber_type == "whisper":
-        return get_whisper_transcriber(model_size, device)
+    if transcriber_type == "fast-whisper":
+        whisper_model_size = os.environ.get("WHISPER_MODEL_SIZE",model_size)
+        return get_whisper_transcriber(whisper_model_size, device=device)
     elif transcriber_type == "bcut":
         return get_bcut_transcriber()
     elif transcriber_type == "kuaishou":
         return get_kuaishou_transcriber()
     else:
         logger.warning(f'未知转录器类型 "{transcriber_type}"，使用默认 whisper')
-        return get_whisper_transcriber(model_size, device)
+        whisper_model_size = os.environ.get("WHISPER_MODEL_SIZE",model_size)
+        return get_whisper_transcriber(whisper_model_size, device)

--- a/backend/app/transcriber/transcriber_provider.py
+++ b/backend/app/transcriber/transcriber_provider.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from app.transcriber.whisper import WhisperTranscriber
 from app.transcriber.bcut import BcutTranscriber
@@ -6,13 +7,26 @@ from app.transcriber.kuaishou import KuaishouTranscriber
 from app.utils.logger import get_logger
 logger = get_logger(__name__)
 
+# 只在Apple平台且设置了环境变量时才导入MLX Whisper
+if platform.system() == "Darwin" and os.environ.get("TRANSCRIBER_TYPE") == "mlx-whisper":
+    try:
+        from app.transcriber.mlx_whisper_transcriber import MLXWhisperTranscriber
+        MLX_WHISPER_AVAILABLE = True
+        logger.info("MLX Whisper 可用，已导入")
+    except ImportError:
+        MLX_WHISPER_AVAILABLE = False
+        logger.warning("MLX Whisper 导入失败，可能未安装或平台不支持")
+else:
+    MLX_WHISPER_AVAILABLE = False
+
 logger.info('初始化转录服务提供器')
 
 # 维护各种转录器的单例实例
 _transcribers = {
     'whisper': None,
     'bcut': None,
-    'kuaishou': None
+    'kuaishou': None,
+    'mlx-whisper': None
 }
 
 def get_whisper_transcriber(model_size="base", device="cuda"):
@@ -51,13 +65,29 @@ def get_kuaishou_transcriber():
             raise
     return _transcribers['kuaishou']
 
+def get_mlx_whisper_transcriber(model_size="base"):
+    """获取 MLX Whisper 转录器实例"""
+    if not MLX_WHISPER_AVAILABLE:
+        logger.warning("MLX Whisper 不可用，请确保在Apple平台且已安装mlx_whisper")
+        raise ImportError("MLX Whisper 不可用，请确保在Apple平台且已安装mlx_whisper")
+        
+    if _transcribers['mlx-whisper'] is None:
+        logger.info(f'创建 MLX Whisper 转录器实例，参数：{model_size}')
+        try:
+            _transcribers['mlx-whisper'] = MLXWhisperTranscriber(model_size=model_size)
+            logger.info('MLX Whisper 转录器创建成功')
+        except Exception as e:
+            logger.error(f"MLX Whisper 转录器创建失败: {e}")
+            raise
+    return _transcribers['mlx-whisper']
+
 def get_transcriber(transcriber_type="fast-whisper", model_size="base", device="cuda"):
     """
     获取指定类型的转录器实例
     
     参数:
-        transcriber_type: 转录器类型，支持 "fast-whisper", "bcut", "kuaishou"
-        model_size: 模型大小，whisper 特有参数
+        transcriber_type: 转录器类型，支持 "fast-whisper", "bcut", "kuaishou", "mlx-whisper"(仅Apple平台)
+        model_size: 模型大小，whisper 和 mlx-whisper 特有参数
         device: 设备类型，whisper 特有参数
     
     返回:
@@ -67,6 +97,12 @@ def get_transcriber(transcriber_type="fast-whisper", model_size="base", device="
     if transcriber_type == "fast-whisper":
         whisper_model_size = os.environ.get("WHISPER_MODEL_SIZE",model_size)
         return get_whisper_transcriber(whisper_model_size, device=device)
+    elif transcriber_type == "mlx-whisper":
+        whisper_model_size = os.environ.get("WHISPER_MODEL_SIZE",model_size)
+        if not MLX_WHISPER_AVAILABLE:
+            logger.warning("MLX Whisper 不可用，回退到 fast-whisper")
+            return get_whisper_transcriber(whisper_model_size, device=device)
+        return get_mlx_whisper_transcriber(whisper_model_size)
     elif transcriber_type == "bcut":
         return get_bcut_transcriber()
     elif transcriber_type == "kuaishou":

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,7 @@ async def startup_event():
 async def startup_event():
     register_handler()
     ensure_ffmpeg_or_raise()
-    get_transcriber()
+    get_transcriber(transcriber_type=os.getenv("TRANSCRIBER_TYPE","fast-whisper"))
     init_video_task_table()
 
 if __name__ == "__main__":


### PR DESCRIPTION
- 支持通过环境变量 TRANSCRIBER_TYPE 配置转写器类型，支持以下三种类型的切换：fast-whisper、bcut、kuaishou。默认情况下为fast-whisper
- 支持通过环境变量 WHISPER_MODEL_SIZE 配置 fast-whisper 使用的模型规模（如 tiny, base, small 等），以便根据实际需求灵活调整模型性能与资源占用。