### PR TITLE
feat: 更新图片路径生成逻辑

### DIFF
--- a/BillNote_frontend/vite.config.ts
+++ b/BillNote_frontend/vite.config.ts
@@ -25,6 +25,11 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: path => path.replace(/^\/api/, '/api'),
         },
+        '/static': {
+          target: apiBaseUrl,
+          changeOrigin: true,
+          rewrite: path => path.replace(/^\/static/, '/static'),
+        },
       },
     },
   }

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -136,7 +136,7 @@ class NoteGenerator:
             for idx, (marker, ts) in enumerate(matches):
                 image_path = generate_screenshot(video_path, output_dir, ts, idx)
                 image_relative_path = os.path.join(image_base_url, os.path.basename(image_path)).replace("\\", "/")
-                image_url = f"{BACKEND_BASE_URL.rstrip('/')}/{image_relative_path.lstrip('/')}"
+                image_url = f"/static/screenshots/{os.path.basename(image_path)}"
                 replacement = f"![]({image_url})"
                 new_markdown = new_markdown.replace(marker, replacement, 1)
 


### PR DESCRIPTION
- 修改了生成截图 URL 的方式，使用相对路径替代绝对路径- 在前端 Vite 配置中添加了对 /static路径的代理设置