### PR TITLE
refactor(.gitignore and vite.config): 更新忽略文件配置和前端端口设置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,4 +319,5 @@ cython_debug/
 /backend/bili_note.db
 /backend/uploads/*
 /backend/.idea/*
+/backend/config/*
 /BiliNote_frontend/.idea/*

--- a/BillNote_frontend/vite.config.ts
+++ b/BillNote_frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd() + '/../')
 
   const apiBaseUrl = env.VITE_API_BASE_URL
+  const port = env.FRONTEND_PORT || 3015
 
   return {
     plugins: [react(), tailwindcss()],
@@ -18,7 +19,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: '0.0.0.0',
-      port: 5173,
+      port: port,
       proxy: {
         '/api': {
           target: apiBaseUrl,


### PR DESCRIPTION
- 在 .gitignore 文件中添加 backend/config/* 和 BiliNo 到忽略列表
- 移除 BiliNote_frontend/.idea/* 以便于前端项目的重构
- 在 vite.config.ts 中添加前端端口配置，使用环境变量或默认值 3015
- 修改服务器端口配置，使用新设置的前端端口