### PR TITLE
refactor(utils): 更新模型目录获取逻辑以支持打包运行

### DIFF
--- a/backend/app/utils/path_helper.py
+++ b/backend/app/utils/path_helper.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from pathlib import Path
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 
@@ -10,11 +12,15 @@ def get_data_dir():
 
 
 def get_model_dir(subdir: str = "whisper") -> str:
-    base = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../models"))
-    path = os.path.join(base, subdir)
+    # 判断是否为打包状态（PyInstaller）
+    if getattr(sys, 'frozen', False):
+        # exe 执行，放在 APPDATA 或 ~/.cache 下
+        base_dir = os.path.join(os.getenv("APPDATA") or str(Path.home()), "BiliNote", "models")
+    else:
+        # 开发时，相对项目根目录
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../models"))
+
+    path = os.path.join(base_dir, subdir)
     os.makedirs(path, exist_ok=True)
     return path
 
-
-if __name__ == '__main__':
-    print(get_data_dir())


### PR DESCRIPTION
-增加对打包状态的判断，使用不同的目录路径
-打包时将模型目录设置为 APPDATA 或 ~/.cache 下的 BiliNote/models
- 开发时仍使用项目根目录下的 models目录
- 确保兼容性和可移植性