### PR TITLE
refactor(backend): 更新默认提供商路径获取方法并配置前端请求基础 URL

### DIFF
--- a/BillNote_frontend/src/utils/request.ts
+++ b/BillNote_frontend/src/utils/request.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const request = axios.create({
-  baseURL: '/api', // 默认请求路径前缀
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
   timeout: 10000,
 })
 

--- a/backend/app/db/provider_dao.py
+++ b/backend/app/db/provider_dao.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from app.db.sqlite_client import get_connection
 from app.utils.logger import get_logger
@@ -7,6 +8,13 @@ from app.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+
+def get_builtin_providers_path():
+    if getattr(sys, 'frozen', False):
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.dirname(__file__)
+    return os.path.join(base_path, 'builtin_providers.json')
 
 def seed_default_providers():
     conn = get_connection()
@@ -24,7 +32,7 @@ def seed_default_providers():
         conn.close()
         return
 
-    json_path = os.path.join(os.path.dirname(__file__), 'builtin_providers.json')
+    json_path = get_builtin_providers_path()
     try:
         with open(json_path, 'r', encoding='utf-8') as f:
             providers = json.load(f)
@@ -47,7 +55,6 @@ def seed_default_providers():
                 p['type'],
                 p.get('enabled', 1)
             ))
-
         conn.commit()
         logger.info("Default providers seeded successfully.")
     except Exception as e:


### PR DESCRIPTION
- 新增 get_builtin_providers_path 函数以动态获取内置提供商 JSON 文件路径
- 修改 seed_default_providers 函数，使用新的路径获取方法
- 更新前端请求工具，配置 API 基础 URL 以适应不同环境