### PR TITLE
feat(utils): 添加 API 路径到请求基础 URL

### DIFF
--- a/BillNote_frontend/src/utils/request.ts
+++ b/BillNote_frontend/src/utils/request.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const request = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
+  baseURL: import.meta.env.VITE_API_BASE_URL + '/api' || 'http://localhost:8000/api',
   timeout: 10000,
 })
 


### PR DESCRIPTION
- 在请求基础 URL 中加入 '/api' 路径 -确保无论是生产环境还是本地环境，请求 URL 都包含 API路径