### PR TITLE
refactor(utils): 优化 request.ts 中的 API 地址配置- 提取 base URL 到单独的常量中

### DIFF
--- a/BillNote_frontend/src/utils/request.ts
+++ b/BillNote_frontend/src/utils/request.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
-
+const baseURL=import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 const request = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL + '/api' || 'http://localhost:8000/api',
+  baseURL: baseURL+'/api',
   timeout: 10000,
 })
 


### PR DESCRIPTION
- 使用 import.meta.env.VITE_API_BASE_URL 或本地地址作为默认值 -简化了代码结构，提高了可读性和可维护性