### PR TITLE
feat(.env.example): 添加 groq 语音识别模型配置选项

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ DATA_DIR=data
 FFMPEG_BIN_PATH=
 
 # transcriber 相关配置
-TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou/mlx-whisper(仅Apple平台)
+TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou/mlx-whisper/groq(仅Apple平台)
 WHISPER_MODEL_SIZE=base
 
+GROQ_TRANSCRIBER_MODEL=whisper-large-v3-turbo # groq提供的faster-whisper 默认为 whisper-large-v3-turbo


### PR DESCRIPTION
- 在 TRANSCRIBER_TYPE 中添加 groq 作为可选的 Apple 平台专用模型
- 新增 GROQ_TRANSCRIBER_MODEL 变量，用于指定 groq 提供的 faster-whisper模型，默认为 whisper-large-v3-turbo