### PR TITLE
feat(nginx): 调整客户端请求体大小限制

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,7 @@
 server {
   listen 80;
-
+  client_max_body_size 10G;
+  client_body_buffer_size 128k;
   # 所有非 /api 请求全部代理给 frontend 容器
   location / {
     proxy_pass http://frontend:80;


### PR DESCRIPTION
- 设置 client_max_body_size 为 10G，允许上传大文件- 设置 client_body_buffer_size 为 128k，优化请求体缓冲