### PR TITLE
Fix duplicate handler registration

### DIFF
--- a/backend/app/gpt/universal_gpt.py
+++ b/backend/app/gpt/universal_gpt.py
@@ -14,7 +14,6 @@ class UniversalGPT(GPT):
         self.model = model
         self.temperature = temperature
         self.screenshot = False
-        self.screenshot = False
         self.link = False
 
     def _format_time(self, seconds: float) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,7 +40,6 @@ async def startup_event():
     register_exception_handlers(app)
     register_handler()
     ensure_ffmpeg_or_raise()
-    register_handler()
     get_transcriber(transcriber_type=os.getenv("TRANSCRIBER_TYPE","fast-whisper"))
     init_video_task_table()
     init_provider_table()


### PR DESCRIPTION
## Summary
- remove duplicate register_handler in `startup_event`
- correct UniversalGPT initialization flag

## Testing
- `python -m py_compile backend/main.py backend/app/gpt/universal_gpt.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa228c1b08320941aee05f7c631d1