### PR TITLE
build(tauri): 更新后端端口并优化打包流程

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # 通用端口配置
-BACKEND_PORT=8000
+BACKEND_PORT=8483 # 后端端口
 FRONTEND_PORT=3015
 BACKEND_HOST=0.0.0.0 # 默认为 0.0.0.0，表示监听所有 IP 地址 不建议动
 APP_PORT= 3015 # docker 部署时用
-# 前端访问后端用（生产环境建议写公网或宿主机 IP）
-VITE_API_BASE_URL=http://127.0.0.1:8000
-VITE_SCREENSHOT_BASE_URL=http://127.0.0.1:8000/static/screenshots
+# 前端访问后端用 (开发环境使用)
+VITE_API_BASE_URL=http://127.0.0.1:8483
+VITE_SCREENSHOT_BASE_URL=http://127.0.0.1:8483/static/screenshots
 VITE_FRONTEND_PORT=3015
 # 生产环境配置
 ENV=production

--- a/BillNote_frontend/.env.tauri
+++ b/BillNote_frontend/.env.tauri
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://127.0.0.1:8483/api
+VITE_PLATFORM=tauri

--- a/BillNote_frontend/src-tauri/tauri.conf.json
+++ b/BillNote_frontend/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:3015",
     "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm build"
+    "beforeBuildCommand": "pnpm build --mode tauri "
   },
   "app": {
     "windows": [

--- a/BillNote_frontend/src/utils/request.ts
+++ b/BillNote_frontend/src/utils/request.ts
@@ -11,10 +11,11 @@ export interface IResponse<T = any> {
 // 模拟一个消息提示函数 (实际项目中会使用UI库的组件，如 Ant Design 的 message 或 Element UI 的 ElMessage)
 // This function simulates a message display (in real projects, you'd use a UI library's component)
 
+const baseURL = import.meta.env.VITE_API_BASE_URL;
 
 // 创建实例
  const request: AxiosInstance = axios.create({
-  baseURL: '/api', // 请确保你的开发服务器代理设置正确
+  baseURL: baseURL || '/api',
   timeout: 10000,
 });
 

--- a/backend/app/services/note.py
+++ b/backend/app/services/note.py
@@ -44,7 +44,7 @@ load_dotenv()
 
 # 后端 API 地址与端口（若有需要可以在代码其他部分使用 BACKEND_BASE_URL）
 API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost")
-BACKEND_PORT = os.getenv("BACKEND_PORT", "8000")
+BACKEND_PORT = os.getenv("BACKEND_PORT", "8483")
 BACKEND_BASE_URL = f"{API_BASE_URL}:{BACKEND_PORT}"
 
 # 输出目录（用于缓存音频、转写、Markdown 文件，以及存储截图）

--- a/backend/build.bat
+++ b/backend/build.bat
@@ -7,23 +7,31 @@ echo 当前工作目录：%cd%
 
 REM 清理旧的构建
 echo 清理旧的构建...
-rmdir /s /q backend\dist 2>nul
-rmdir /s /q backend\build 2>nul
-rmdir /s /q BillNote_frontend\src-tauri\bin 2>nul
-mkdir BillNote_frontend\src-tauri\bin\BiliNoteBackend
+if exist backend\dist rmdir /s /q backend\dist
+if exist backend\build rmdir /s /q backend\build
+if exist BillNote_frontend\src-tauri\bin rmdir /s /q BillNote_frontend\src-tauri\bin
 echo 清理完成。
+
+REM 重新创建 Tauri 需要的目录结构
+mkdir BillNote_frontend\src-tauri\bin
 
 REM 获取 Rust 的 target triple（适配 Tauri 对应平台）
 for /f "tokens=2 delims=:" %%A in ('rustc -Vv ^| findstr "host"') do (
     set "TARGET_TRIPLE=%%A"
 )
-set "TARGET_TRIPLE=%TARGET_TRIPLE: =%"  REM 去除多余空格
+set "TARGET_TRIPLE=%TARGET_TRIPLE: =%"
 echo Detected target triple: %TARGET_TRIPLE%
 
-REM 执行 PyInstaller 打包
+
+REM --- 核心修改部分开始 ---
+
+REM 步骤 1: 为了避免 PyInstaller 的解析歧义，我们先手动复制文件
+echo 为打包准备 .env 文件...
+copy .env.example backend/.env
+
+REM 步骤 2: 执行 PyInstaller 打包，直接添加已存在的 .env 文件
 echo 开始 PyInstaller 打包...
 pyinstaller ^
-  --clean ^
   -y ^
   --name BiliNoteBackend ^
   --paths backend ^
@@ -33,9 +41,16 @@ pyinstaller ^
   --hidden-import uvicorn ^
   --hidden-import fastapi ^
   --hidden-import starlette ^
-  --add-data "app/db/builtin_providers.json;." ^
-  --add-data "..\.env.example;.env" ^
+  --add-data "app\db\builtin_providers.json;." ^
+  --add-data ".env;." ^
   backend\main.py
+
+REM 步骤 3: 清理在项目根目录创建的临时 .env 文件
+echo 清理临时的 .env 文件...
+del backend/.env
+
+REM --- 核心修改部分结束 ---
+
 
 REM 重命名生成的可执行文件为符合 Tauri 要求的名称
 move /Y BillNote_frontend\src-tauri\bin\BiliNoteBackend\BiliNoteBackend.exe BillNote_frontend\src-tauri\bin\BiliNoteBackend\BiliNoteBackend-%TARGET_TRIPLE%.exe
@@ -43,5 +58,6 @@ move /Y BillNote_frontend\src-tauri\bin\BiliNoteBackend\BiliNoteBackend.exe Bill
 echo PyInstaller 打包完成：
 dir BillNote_frontend\src-tauri\bin\BiliNoteBackend
 
-echo 请检查 BillNote_frontend\src-tauri\bin\BiliNoteBackend 目录，以确认打包内容。
+echo 请检查 BillNote_frontend\src-tauri\bin\BiliNoteBackend 目录，确认其中包含了名为 .env 的【文件】。
+
 endlocal

--- a/backend/main.py
+++ b/backend/main.py
@@ -66,7 +66,7 @@ app.mount("/uploads", StaticFiles(directory=uploads_dir), name="uploads")
 
 
 if __name__ == "__main__":
-    port = int(os.getenv("BACKEND_PORT", 8000))
+    port = int(os.getenv("BACKEND_PORT", 8483))
     host = os.getenv("BACKEND_HOST", "0.0.0.0")
     logger.info(f"Starting server on {host}:{port}")
     uvicorn.run(app, host=host, port=port, reload=False)


### PR DESCRIPTION
- 将后端端口从8000 修改为 8483
- 更新前端请求基础 URL 以匹配新的后端端口
- 优化后端打包脚本，确保 .env 文件正确复制和清理
- 修改后端主程序和请求工具中的端口配置