### PR TITLE
docs: 更新 README 中微信交流群图片链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo apt install ffmpeg
 - BiliNote 交流QQ群：785367111
 - BiliNote 交流微信群:
   
-  <img src="https://common-1304618721.cos.ap-chengdu.myqcloud.com/20250608111120288.png" alt="wechat" style="zoom:33%;" />
+  <img src="doc/wechat.png" alt="wechat" style="zoom:33%;" />
 
 
 


### PR DESCRIPTION
- 将微信交流群图片链接从外部 URL 更改为本地文件路径
- 从腾讯云存储地址改为相对路径的图片文件