### PR TITLE
修复哔哩哔哩视频原片url问题

### DIFF
--- a/backend/app/utils/note_helper.py
+++ b/backend/app/utils/note_helper.py
@@ -18,7 +18,8 @@ def replace_content_markers(markdown: str, video_id: str, platform: str = 'bilib
         total_seconds = int(mm) * 60 + int(ss)
 
         if platform == 'bilibili':
-            url = f"https://www.bilibili.com/video/{video_id}?t={total_seconds}"
+            video_id = video_id.replace("_p", "?p=")
+            url = f"https://www.bilibili.com/video/{video_id}&t={total_seconds}"
         elif platform == 'youtube':
             url = f"https://www.youtube.com/watch?v={video_id}&t={total_seconds}s"
         elif platform == 'douyin':


### PR DESCRIPTION
在包含多个哔哩哔哩视频的集合中，原片url中video_id为XXX_pN的格式，无法打开跳转到指定时间，需改为XXX?p=N的格式