### PR TITLE
再次优化 B站时间戳跳转格式

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ FRONTEND_PORT=3015
 BACKEND_HOST=0.0.0.0 # 默认为 0.0.0.0，表示监听所有 IP 地址 不建议动
 APP_PORT= 3015 # docker 部署时用
 # 前端访问后端用 (开发环境使用)
-VITE_API_BASE_URL=http://127.0.0.1:8483
+VITE_API_BASE_URL=http://127.0.0.1:8000
 VITE_SCREENSHOT_BASE_URL=http://127.0.0.1:8483/static/screenshots
 VITE_FRONTEND_PORT=3015
 # 生产环境配置
@@ -19,6 +19,6 @@ FFMPEG_BIN_PATH=
 
 # transcriber 相关配置
 TRANSCRIBER_TYPE=fast-whisper # fast-whisper/bcut/kuaishou/mlx-whisper(仅Apple平台)/groq
-WHISPER_MODEL_SIZE=base
+WHISPER_MODEL_SIZE=medium
 
 GROQ_TRANSCRIBER_MODEL=whisper-large-v3-turbo # groq提供的faster-whisper 默认为 whisper-large-v3-turbo

--- a/BillNote_frontend/vite.config.ts
+++ b/BillNote_frontend/vite.config.ts
@@ -7,7 +7,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd() + '/../')
 
-  const apiBaseUrl = env.VITE_API_BASE_URL || 'http://localhost:8000'
+  const apiBaseUrl = env.VITE_API_BASE_URL || 'http://127.0.0.1:8483'
   const port = parseInt(env.VITE_FRONTEND_PORT || '3015', 10)
 
   return {

--- a/backend/app/utils/note_helper.py
+++ b/backend/app/utils/note_helper.py
@@ -1,13 +1,9 @@
 import re
 
-
-import re
-
-import re
-
 def replace_content_markers(markdown: str, video_id: str, platform: str = 'bilibili') -> str:
     """
-    替换 *Content-04:16*、Content-04:16 或 Content-[04:16] 为超链接，跳转到对应平台视频的时间位置
+    替换 *Content-04:16*、Content-04:16 或 Content-[04:16] 为超链接
+    目标格式：- [04:16](https://www.bilibili.com/video/BVxxx?t=256#t=04:16)
     """
     # 匹配三种形式：*Content-04:16*、Content-04:16、Content-[04:16]
     pattern = r"(?:\*?)Content-(?:\[(\d{2}):(\d{2})\]|(\d{2}):(\d{2}))"
@@ -16,18 +12,28 @@ def replace_content_markers(markdown: str, video_id: str, platform: str = 'bilib
         mm = match.group(1) or match.group(3)
         ss = match.group(2) or match.group(4)
         total_seconds = int(mm) * 60 + int(ss)
+        time_str = f"{mm}:{ss}"
 
         if platform == 'bilibili':
-            video_id = video_id.replace("_p", "?p=")
-            url = f"https://www.bilibili.com/video/{video_id}&t={total_seconds}"
+            # 处理多 P 情况，如果是 BV123_p3 转换为 BV123?p=3
+            actual_video_id = video_id.replace("_p", "?p=")
+            
+            # 判断连接符是 ? 还是 & (如果 video_id 里已经有了 ?p=，则时间参数用 &t=)
+            connector = "&t=" if "?" in actual_video_id else "?t="
+            
+            # 拼接最终 URL，并在末尾加上 #t=MM:SS 锚点
+            url = f"https://www.bilibili.com/video/{actual_video_id}{connector}{total_seconds}#t={time_str}"
+            return f"- [{time_str}]({url})"
+
         elif platform == 'youtube':
             url = f"https://www.youtube.com/watch?v={video_id}&t={total_seconds}s"
+            return f"- [{time_str}]({url})"
+
         elif platform == 'douyin':
             url = f"https://www.douyin.com/video/{video_id}"
-            return f"[原片 @ {mm}:{ss}]({url})"
+            return f"[原片 @ {time_str}]({url})"
+            
         else:
-            return f"({mm}:{ss})"
-
-        return f"[原片 @ {mm}:{ss}]({url})"
+            return f"({time_str})"
 
     return re.sub(pattern, replacer, markdown)


### PR DESCRIPTION
fix: update bilibili timestamp link format to - [MM:SS](URL#t=MM:SS)
修改了时间戳转换逻辑，使其符合 - [MM:SS](URL#t=MM:SS) 格式，确保在还p是 B站播放器中能更准确地定位。