### PR TITLE
fix(docker): 修复前端构建时缺少 .env 文件的问题

### DIFF
--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -36,6 +36,9 @@ WORKDIR /tmp/frontend
 COPY ./BillNote_frontend/package.json ./
 RUN pnpm install
 
+# 复制 .env.example 到父目录，供 vite.config.ts 使用
+COPY ./.env.example /tmp/.env
+
 COPY ./BillNote_frontend /tmp/frontend
 RUN pnpm run build
 


### PR DESCRIPTION
在构建前端之前复制 .env.example 到父目录，供 vite.config.ts 加载环境变量使用