### PR TITLE
fix(frontend): 修复 ESM 模式下 __dirname 未定义的问题

### DIFF
--- a/BillNote_frontend/vite.config.ts
+++ b/BillNote_frontend/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import tailwindcss from '@tailwindcss/vite'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
在 vite.config.ts 中添加 ESM 兼容的 __dirname 定义，修复 Docker 构建时的配置加载错误