### PR TITLE
fix(ci): 移除 pnpm install 的 --frozen-lockfile 标志

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: BillNote_frontend
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       # 设置 Rust 环境
       - name: Set up Rust


### PR DESCRIPTION
由于不提交 pnpm-lock.yaml 文件，移除 --frozen-lockfile 标志以修复桌面端构建失败