### PR TITLE
feat(frontend): migrate Zustand persist storage to IndexedDB

### DIFF
--- a/BillNote_frontend/package.json
+++ b/BillNote_frontend/package.json
@@ -33,6 +33,7 @@
     "clsx": "^2.1.1",
     "fuse.js": "^7.1.0",
     "github-markdown-css": "^5.8.1",
+    "idb-keyval": "^6.2.2",
     "jszip": "^3.10.1",
     "katex": "^0.16.22",
     "lottie-react": "^2.4.1",

--- a/BillNote_frontend/src/store/taskStore/index.ts
+++ b/BillNote_frontend/src/store/taskStore/index.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { delete_task, generateNote } from '@/services/note.ts'
 import { v4 as uuidv4 } from 'uuid'
 import toast from 'react-hot-toast'
+import { get, set, del } from 'idb-keyval'
 
 
 export type TaskStatus = 'PENDING' | 'RUNNING' | 'SUCCESS' | 'FAILD'
@@ -211,6 +212,18 @@ export const useTaskStore = create<TaskStore>()(
     }),
     {
       name: 'task-storage',
+      storage: createJSONStorage(() => ({
+        getItem: async (name: string): Promise<string | null> => {
+          const value = await get(name)
+          return value ?? null
+        },
+        setItem: async (name: string, value: string): Promise<void> => {
+          await set(name, value)
+        },
+        removeItem: async (name: string): Promise<void> => {
+          await del(name)
+        },
+      })),
     }
   )
 )


### PR DESCRIPTION
## Summary
- 添加 `idb-keyval` 依赖，使用 IndexedDB 替代 localStorage 作为 Zustand persist 的存储后端
- 提升浏览器环境下的持久化可靠性

## Files Changed
- `BillNote_frontend/package.json` - 添加 idb-keyval 依赖
- `BillNote_frontend/src/store/taskStore/index.ts` - 配置 persist 使用 IndexedDB

## Patch File
https://gist.github.com/linwinfan/54e072b68d7655e0dc322dc569c1168e

## Test Plan
- [ ] 运行 `pnpm install` 安装新依赖
- [ ] 验证任务状态在页面刷新后正确恢复
- [ ] 确认 IndexedDB 中正确存储了 task-storage 数据