### PR TITLE
fix(ci): commitlint workflow 去掉伪 input + 规范 release merge commit 格式

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -26,7 +26,5 @@ jobs:
         uses: wagoid/commitlint-github-action@v6
         with:
           configFile: .commitlintrc.json
-          # PR 上检查 base..head 之间所有 commit；push 上只校验最新 commit
-          firstParent: false
           failOnWarnings: false
           helpURL: https://github.com/JefferyHcool/BiliNote/blob/develop/CONTRIBUTING.md#5-提交规范

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,7 @@ chore(ci): 优化 docker 构建缓存
 
 - `feature/*` / `fix/*` 合入 `develop`：推荐 **Squash and merge**，保持 develop 历史线性。
 - `release/*` 合入 `master` 与回灌 `develop`：使用 **Merge commit (--no-ff)**，保留发版结构。
+  · merge commit 标题用 `chore(release): vX.Y.Z`（合 master）或 `chore(release): merge release/X.Y.Z back into develop`（回灌 develop），保证 commitlint 通过。
 - `hotfix/*` 同上 release。
 
 ### 6.4 合并后

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,10 +42,13 @@ git push -u origin release/X.Y.Z
 
 在 GitHub 上发起两个 PR：
 
-| PR | base | 合并方式 |
-|---|---|---|
-| `release/X.Y.Z` → `master` | `master` | **Merge commit (--no-ff)** |
-| `release/X.Y.Z` → `develop` | `develop` | **Merge commit (--no-ff)** |
+| PR | base | 合并方式 | 合并后 commit 标题 |
+|---|---|---|---|
+| `release/X.Y.Z` → `master` | `master` | **Merge commit (--no-ff)** | `chore(release): vX.Y.Z` |
+| `release/X.Y.Z` → `develop` | `develop` | **Merge commit (--no-ff)** | `chore(release): merge release/X.Y.Z back into develop` |
+
+> ⚠️ Merge commit 的标题**必须**符合 `type(scope): subject` 格式（commitlint 在 push 到 master/develop 时会校验）。
+> 历史上用过 `Release vX.Y.Z` 这种形式，会被 commitlint 报 `type-empty` / `subject-empty`。
 
 `master` 分支保护要求 review 通过。回灌 `develop` 是为了把发版冻结期内的小修同步回来。
 


### PR DESCRIPTION
v2.1.3 push master 时 Lint commit messages job 红了，根因两条：

1. workflow 里写了 'firstParent: false'，但 wagoid/commitlint-github-action@v6 的合法 input 列表里没这个字段，被 ignore 同时打 warn

2. release merge commit 标题 'Release v2.1.3' 不符合 type(scope): subject 格式， commitlint 报 subject-empty + type-empty · @commitlint/config-conventional 默认 ignore 'Merge ' 前缀的 commit， 但我们手动 -m 把标题写成 'Release vX.Y.Z' 跳过了豁免

修：
- 去掉 .github/workflows/commitlint.yml 里那条 firstParent 假 input
- RELEASING.md §3 加入 merge commit 标题模板： · 合 master 用 'chore(release): vX.Y.Z' · 回灌 develop 用 'chore(release): merge release/X.Y.Z back into develop'
- CONTRIBUTING.md §6.3 同步加这条提醒

历史上 master / develop 的 'Release v2.1.x' 那几个 merge commit 已经在 history 里，没法回头改（不能强推 master）。但 commitlint 在 push 时只 lint 推送范围里的 新 commit，旧 commit 不会重新校验，所以不会持续报错。

<!--
PR 标题请遵循 type(scope): subject 格式，例如：
  feat(extension): 侧边栏接入思维导图
  fix(bilibili): 修正字幕优先链路在未登录态下的回退
分支命名 / 提交规范见 CONTRIBUTING.md。
-->

## 改动概述

<!-- 一句话说清这个 PR 做了什么 -->

## 为什么

<!-- 背景、关联 issue（Fixes #xxx / Refs #xxx）、用户场景 -->

## 做了什么

<!-- 关键文件、关键决策。可贴关键片段或截图 -->

## 测试方式

- [ ] `pnpm typecheck && pnpm build`（前端 / 插件）通过
- [ ] `python -m py_compile <文件>` 或本地 backend 启动验证（后端）通过
- [ ] 手动验证步骤：
  <!-- 描述如何复现验证；UI 改动请附截图 / 录屏 -->

## 回归风险

<!-- 影响面、可能受波及的功能、是否需要前后端 / 配置 同步部署 -->

## Checklist

- [ ] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [ ] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [ ] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [ ] 已自测核心流程
- [ ] 已更新相关文档（`README.md` / `CHANGELOG.md` / `CLAUDE.md` / 模块 README，如适用）
- [ ] 未夹带 secrets / `.env` / 大型二进制
- [ ] 单 PR 不跨多个工作区做无关改动
