### PR TITLE
feat(transcriber): 默认 size 改 tiny + 切本地引擎前 confirm 模型下载

### DIFF
--- a/BillNote_frontend/src/pages/SettingPage/transcriber.tsx
+++ b/BillNote_frontend/src/pages/SettingPage/transcriber.tsx
@@ -73,6 +73,28 @@ export default function Transcriber() {
   }, [modelStatuses, mlxModelStatuses, fetchModelsStatus])
 
   const handleSave = async () => {
+    // 切到本地 whisper 引擎且选了未下载的模型时，提前 confirm，避免用户保存后到首次任务才发现要下 GB 级模型
+    if (isWhisperType(selectedType)) {
+      const pool = selectedType === 'mlx-whisper' ? mlxModelStatuses : modelStatuses
+      const target = pool.find(m => m.model_size === selectedModelSize)
+      if (target && !target.downloaded && !target.downloading) {
+        const sizeHint: Record<string, string> = {
+          'tiny': '~75MB',
+          'base': '~150MB',
+          'small': '~500MB',
+          'medium': '~1.5GB',
+          'large-v3': '~3GB',
+          'large-v3-turbo': '~1.6GB',
+        }
+        const ok = window.confirm(
+          `选择 ${selectedType} / ${selectedModelSize} 后，首次转写时会下载该模型（${sizeHint[selectedModelSize] || '体积未知'}）。\n` +
+          `网络较差时容易中断；推荐改用 Groq / 必剪 / 快手 等在线引擎。\n\n` +
+          '继续保存吗？',
+        )
+        if (!ok) return
+      }
+    }
+
     setSaving(true)
     try {
       const payload: { transcriber_type: string; whisper_model_size?: string } = {

--- a/backend/app/services/transcriber_config_manager.py
+++ b/backend/app/services/transcriber_config_manager.py
@@ -25,7 +25,12 @@ class TranscriberConfigManager:
             json.dump(data, f, ensure_ascii=False, indent=2)
 
     def get_config(self) -> Dict[str, Any]:
-        """获取当前转写器配置，fallback 到环境变量默认值。"""
+        """获取当前转写器配置，fallback 到环境变量默认值。
+
+        whisper 默认 size 从 'medium' (~1.5GB) 改为 'tiny' (~75MB)：
+        新装用户没主动设置时不应该被首次下载卡住。想要更高精度可在「音频转写配置」
+        页主动切换。
+        """
         data = self._read()
         return {
             "transcriber_type": data.get(
@@ -34,7 +39,7 @@ class TranscriberConfigManager:
             ),
             "whisper_model_size": data.get(
                 "whisper_model_size",
-                os.getenv("WHISPER_MODEL_SIZE", "medium"),
+                os.getenv("WHISPER_MODEL_SIZE", "tiny"),
             ),
         }
 


### PR DESCRIPTION
桌面端用户首次跑视频时挂在 fast-whisper 模型下载（默认 medium ~1.5GB）， 两处改动：

1. backend/app/services/transcriber_config_manager.py: 默认 whisper_model_size 从 'medium' (~1.5GB) → 'tiny' (~75MB)。 新装用户没主动设置时不再被首次下载卡住；想要更高精度的用户去配置页主动切。

2. BillNote_frontend/src/pages/SettingPage/transcriber.tsx: handleSave 在保存前判断：选了 fast-whisper / mlx-whisper 且当前 size 在 modelStatuses 里既未下载也不在下载中 → window.confirm 弹一个体积提示， 推荐改用 Groq / 必剪 / 快手 等在线引擎；用户取消则不保存。

不改业务逻辑；零回归风险（已有用户 transcriber.json 里写了什么就还是什么）。

<!--
PR 标题请遵循 type(scope): subject 格式，例如：
  feat(extension): 侧边栏接入思维导图
  fix(bilibili): 修正字幕优先链路在未登录态下的回退
分支命名 / 提交规范见 CONTRIBUTING.md。
-->

## 改动概述

<!-- 一句话说清这个 PR 做了什么 -->

## 为什么

<!-- 背景、关联 issue（Fixes #xxx / Refs #xxx）、用户场景 -->

## 做了什么

<!-- 关键文件、关键决策。可贴关键片段或截图 -->

## 测试方式

- [ ] `pnpm typecheck && pnpm build`（前端 / 插件）通过
- [ ] `python -m py_compile <文件>` 或本地 backend 启动验证（后端）通过
- [ ] 手动验证步骤：
  <!-- 描述如何复现验证；UI 改动请附截图 / 录屏 -->

## 回归风险

<!-- 影响面、可能受波及的功能、是否需要前后端 / 配置 同步部署 -->

## Checklist

- [ ] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [ ] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [ ] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [ ] 已自测核心流程
- [ ] 已更新相关文档（`README.md` / `CHANGELOG.md` / `CLAUDE.md` / 模块 README，如适用）
- [ ] 未夹带 secrets / `.env` / 大型二进制
- [ ] 单 PR 不跨多个工作区做无关改动
