### PR TITLE
feat(desktop): Sidecar 健康度面板 + 重启后端能力

### DIFF
--- a/BillNote_frontend/src-tauri/src/lib.rs
+++ b/BillNote_frontend/src-tauri/src/lib.rs
@@ -1,10 +1,14 @@
-use tauri::{Manager, Emitter};
+use tauri::{Manager, Emitter, State};
 use tauri_plugin_shell::ShellExt;
-use tauri_plugin_shell::process::CommandEvent;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use std::env;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Mutex;
 use serde::Serialize;
+
+// Sidecar 子进程句柄，用 Mutex 包裹方便 restart 时杀旧进程
+struct SidecarHandle(Mutex<Option<CommandChild>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -20,7 +24,6 @@ pub fn run() {
             }
 
             let exe_path = env::current_exe().expect("无法获取当前可执行文件路径");
-            let sidecar_dir = exe_path.parent().expect("无法获取可执行文件的父目录");
 
             // 安装路径诊断：PyInstaller sidecar 在含非 ASCII / 空格的路径下经常炸（README 已警告但缺主动防御）
             // 命中时把诊断信息 emit 给前端，由顶端横幅展示，不阻断启动
@@ -37,75 +40,15 @@ pub fn run() {
                 });
             }
 
-            // 收集所有系统环境变量
-            let mut all_env_vars = HashMap::new();
-            for (key, value) in env::vars() {
-                all_env_vars.insert(key, value);
-            }
-
-            // 增强 PATH 环境变量，添加常见的二进制路径
-            let current_path = all_env_vars.get("PATH").cloned().unwrap_or_default();
-            let additional_paths = get_additional_binary_paths();
-            let enhanced_path = enhance_path_variable(&current_path, &additional_paths);
-            all_env_vars.insert("PATH".to_string(), enhanced_path);
-
-            // 打印一些关键环境变量用于调试
-            println!("Enhanced PATH: {}", all_env_vars.get("PATH").unwrap_or(&"Not found".to_string()));
-            println!("Total environment variables: {}", all_env_vars.len());
-
             // 检查 ffmpeg 是否在 PATH 中可用
             check_ffmpeg_availability();
 
-            // 启动 Python 后端侧车
-            let mut sidecar_command = app.shell().sidecar("BiliNoteBackend").unwrap();
-
-            // 设置所有环境变量到 sidecar
-            for (key, value) in &all_env_vars {
-                sidecar_command = sidecar_command.env(key, value);
-            }
-
-            let (mut rx, _child) = sidecar_command
-                .current_dir(sidecar_dir)
-                .spawn()
-                .expect("Failed to spawn sidecar");
-
-            // 获取主窗口句柄用于发送事件
-            let window = app.get_webview_window("main").unwrap();
-
-            tauri::async_runtime::spawn(async move {
-                // 读取诸如 stdout 之类的事件
-                while let Some(event) = rx.recv().await {
-                    match event {
-                        CommandEvent::Stdout(line) => {
-                            let output = String::from_utf8_lossy(&line);
-                            println!("Backend stdout: {}", output);
-
-                            // 发送到前端
-                            window
-                                .emit("backend-message", Some(format!("'{}'", output)))
-                                .expect("failed to emit event");
-                        }
-                        CommandEvent::Stderr(line) => {
-                            let error = String::from_utf8_lossy(&line);
-                            eprintln!("Backend stderr: {}", error);
-
-                            window
-                                .emit("backend-error", Some(format!("'{}'", error)))
-                                .expect("failed to emit event");
-                        }
-                        CommandEvent::Terminated(payload) => {
-                            println!("Backend terminated with code: {:?}", payload.code);
-                            window
-                                .emit("backend-terminated", Some(payload.code))
-                                .expect("failed to emit event");
-                            break;
-                        }
-                        _ => {
-                            println!("Backend event: {:?}", event);
-                        }
-                    }
-                }
-            });
+            // 启动 Sidecar 并把 child handle 存到 state，方便后续 restart_backend_sidecar 使用
+            let child = spawn_backend_sidecar(app.handle()).map_err(|e| {
+                eprintln!("Sidecar 启动失败: {}", e);
+                e
+            })?;
+            app.manage(SidecarHandle(Mutex::new(Some(child))));
 
             Ok(())
         })
@@ -114,7 +57,8 @@ pub fn run() {
             find_executable_path,
             run_command_with_env,
             test_ffmpeg_access,
-            get_install_path_diagnostics
+            get_install_path_diagnostics,
+            restart_backend_sidecar
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -284,6 +228,102 @@ async fn run_command_with_env(
 #[tauri::command]
 async fn test_ffmpeg_access() -> Result<String, String> {
     run_command_with_env("ffmpeg".to_string(), vec!["-version".to_string()]).await
+}
+
+// 启动后端 Sidecar：负责装环境变量、spawn、挂 stdout/stderr/terminated 监听并 emit 给前端。
+// 第一次启动 + restart_backend_sidecar 都走这里，保持单一启动路径。
+fn spawn_backend_sidecar(app_handle: &tauri::AppHandle) -> Result<CommandChild, String> {
+    let exe_path = env::current_exe().map_err(|e| format!("无法获取可执行文件路径: {}", e))?;
+    let sidecar_dir = exe_path
+        .parent()
+        .ok_or("无法获取可执行文件父目录")?
+        .to_path_buf();
+
+    // 收集所有系统环境变量并增强 PATH（含 ffmpeg 常见安装位置）
+    let mut all_env_vars = HashMap::new();
+    for (key, value) in env::vars() {
+        all_env_vars.insert(key, value);
+    }
+    let current_path = all_env_vars.get("PATH").cloned().unwrap_or_default();
+    let additional_paths = get_additional_binary_paths();
+    let enhanced_path = enhance_path_variable(&current_path, &additional_paths);
+    all_env_vars.insert("PATH".to_string(), enhanced_path);
+
+    let mut sidecar_command = app_handle
+        .shell()
+        .sidecar("BiliNoteBackend")
+        .map_err(|e| format!("找不到 BiliNoteBackend sidecar: {}", e))?;
+    for (key, value) in &all_env_vars {
+        sidecar_command = sidecar_command.env(key, value);
+    }
+
+    let (mut rx, child) = sidecar_command
+        .current_dir(sidecar_dir)
+        .spawn()
+        .map_err(|e| format!("spawn sidecar 失败: {}", e))?;
+
+    // 异步监听 stdout / stderr / terminated 事件，转发到前端 webview
+    let app_handle_for_listener = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            // window 句柄每次重新取，允许窗口关闭重开
+            let window = app_handle_for_listener.get_webview_window("main");
+            match event {
+                CommandEvent::Stdout(line) => {
+                    let output = String::from_utf8_lossy(&line).to_string();
+                    println!("Backend stdout: {}", output);
+                    if let Some(w) = window {
+                        let _ = w.emit("backend-message", Some(output));
+                    }
+                }
+                CommandEvent::Stderr(line) => {
+                    let error = String::from_utf8_lossy(&line).to_string();
+                    eprintln!("Backend stderr: {}", error);
+                    if let Some(w) = window {
+                        let _ = w.emit("backend-error", Some(error));
+                    }
+                }
+                CommandEvent::Terminated(payload) => {
+                    println!("Backend terminated with code: {:?}", payload.code);
+                    if let Some(w) = window {
+                        let _ = w.emit("backend-terminated", Some(payload.code));
+                    }
+                    break;
+                }
+                _ => {
+                    println!("Backend event: {:?}", event);
+                }
+            }
+        }
+    });
+
+    Ok(child)
+}
+
+// 重启 sidecar：杀旧 child，spawn 新 child，回写到 state。
+#[tauri::command]
+fn restart_backend_sidecar(
+    state: State<'_, SidecarHandle>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    // 1. 拿出旧 child 并 kill（kill 失败也继续，可能进程已经退了）
+    {
+        let mut guard = state.0.lock().map_err(|e| format!("锁 sidecar state 失败: {}", e))?;
+        if let Some(child) = guard.take() {
+            let _ = child.kill();
+        }
+    }
+    // 2. 重新 spawn
+    let new_child = spawn_backend_sidecar(&app)?;
+    {
+        let mut guard = state.0.lock().map_err(|e| format!("锁 sidecar state 失败: {}", e))?;
+        *guard = Some(new_child);
+    }
+    // 3. emit 一个事件让前端知道已重启
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.emit("backend-restarted", ());
+    }
+    Ok(())
 }
 
 // 安装路径诊断：PyInstaller 在含非 ASCII / 空格的路径下加载 _internal/* 经常炸；

--- a/BillNote_frontend/src/App.tsx
+++ b/BillNote_frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useCheckBackend } from '@/hooks/useCheckBackend.ts'
 import { systemCheck } from '@/services/system.ts'
 import BackendInitDialog from '@/components/BackendInitDialog'
 import StartupBanner from '@/components/SystemDiagnostic/StartupBanner'
+import BackendHealthIndicator from '@/components/BackendHealth/BackendHealthIndicator'
 import Index from '@/pages/Index.tsx'
 import { HomePage } from './pages/HomePage/Home.tsx'
 
@@ -45,6 +46,7 @@ function App() {
   return (
     <>
       <StartupBanner />
+      <BackendHealthIndicator />
       <BrowserRouter>
         <Suspense fallback={<div className="flex h-screen items-center justify-center">加载中…</div>}>
           <Routes>

--- a/BillNote_frontend/src/components/BackendHealth/BackendHealthIndicator.tsx
+++ b/BillNote_frontend/src/components/BackendHealth/BackendHealthIndicator.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+import { useBackendEvents } from './useBackendEvents'
+import BackendLogPanel from './BackendLogPanel'
+
+// 健康度判定：
+// - 绿：sidecar running 且 /sys_health 通
+// - 黄：sidecar running 但 /sys_health 失败 (ffmpeg 缺等)
+// - 红：sidecar terminated 或 /sys_health 连续 3 次失败
+
+type Health = 'green' | 'yellow' | 'red' | 'unknown'
+
+const HEALTH_POLL_MS = 5000
+const SYS_HEALTH_PATH = '/api/sys_health'
+
+function backendBase(): string {
+  // 与 services/request.ts 用的一致
+  const fromEnv = (import.meta as any).env?.VITE_API_BASE_URL as string | undefined
+  return (fromEnv ?? '').replace(/\/$/, '')
+}
+
+const BackendHealthIndicator = () => {
+  const { status, isTauri, exitCode, logs, restart, copyLogs } = useBackendEvents()
+  const [open, setOpen] = useState(false)
+  const [healthCheckFailures, setHealthCheckFailures] = useState(0)
+  const [lastHealthOk, setLastHealthOk] = useState<boolean | null>(null)
+
+  // 仅在 Tauri 环境挂指示器；纯 web 用户由 useCheckBackend 接管
+  useEffect(() => {
+    if (!isTauri) return
+    let mounted = true
+
+    async function ping() {
+      try {
+        const res = await fetch(`${backendBase()}${SYS_HEALTH_PATH}`)
+        const ok = res.ok
+        if (!mounted) return
+        if (ok) {
+          setHealthCheckFailures(0)
+          setLastHealthOk(true)
+        }
+        else {
+          setHealthCheckFailures(c => c + 1)
+          setLastHealthOk(false)
+        }
+      }
+      catch {
+        if (!mounted) return
+        setHealthCheckFailures(c => c + 1)
+        setLastHealthOk(false)
+      }
+    }
+
+    ping()
+    const t = setInterval(ping, HEALTH_POLL_MS)
+    return () => {
+      mounted = false
+      clearInterval(t)
+    }
+  }, [isTauri])
+
+  if (!isTauri) return null
+
+  const health: Health = (() => {
+    if (status === 'terminated') return 'red'
+    if (healthCheckFailures >= 3) return 'red'
+    if (lastHealthOk === false) return 'yellow'
+    if (lastHealthOk === true) return 'green'
+    return 'unknown'
+  })()
+
+  const colorMap: Record<Health, string> = {
+    green: 'bg-green-500',
+    yellow: 'bg-amber-500',
+    red: 'bg-red-500',
+    unknown: 'bg-gray-400',
+  }
+
+  const labelMap: Record<Health, string> = {
+    green: '后端运行正常',
+    yellow: '后端运行中（部分检查未通过）',
+    red: status === 'terminated' ? `后端已退出 (code=${exitCode ?? 'unknown'})` : '后端无响应',
+    unknown: '后端状态未知',
+  }
+
+  return (
+    <>
+      <button
+        className="fixed right-3 bottom-3 z-[9998] flex items-center gap-2 rounded-full border bg-white px-3 py-1.5 text-xs shadow hover:shadow-md"
+        title={labelMap[health]}
+        onClick={() => setOpen(true)}
+      >
+        <span className={`inline-block h-2 w-2 rounded-full ${colorMap[health]}${health === 'red' || health === 'yellow' ? ' animate-pulse' : ''}`} />
+        <span className="text-gray-700">后端</span>
+      </button>
+
+      {open && (
+        <BackendLogPanel
+          status={status}
+          exitCode={exitCode}
+          logs={logs}
+          health={health}
+          onRestart={restart}
+          onCopyLogs={copyLogs}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+export default BackendHealthIndicator

--- a/BillNote_frontend/src/components/BackendHealth/BackendLogPanel.tsx
+++ b/BillNote_frontend/src/components/BackendHealth/BackendLogPanel.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react'
+import type { LogEntry, BackendStatus } from './useBackendEvents'
+
+interface Props {
+  status: BackendStatus
+  exitCode: number | null
+  logs: LogEntry[]
+  health: 'green' | 'yellow' | 'red' | 'unknown'
+  onRestart: () => Promise<void>
+  onCopyLogs: () => Promise<boolean>
+  onClose: () => void
+}
+
+const BackendLogPanel = ({ status, exitCode, logs, health, onRestart, onCopyLogs, onClose }: Props) => {
+  const [restarting, setRestarting] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // 新日志进来自动滚到底
+  useEffect(() => {
+    if (scrollRef.current)
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  }, [logs])
+
+  async function handleRestart() {
+    setRestarting(true)
+    try { await onRestart() }
+    catch { /* errors already in log via useBackendEvents */ }
+    finally { setRestarting(false) }
+  }
+
+  async function handleCopy() {
+    const ok = await onCopyLogs()
+    setCopied(ok)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <>
+      {/* 半透明遮罩 */}
+      <div className="fixed inset-0 z-[9998] bg-black/20" onClick={onClose} />
+
+      <aside className="fixed right-0 bottom-0 top-0 z-[9999] flex w-[480px] max-w-[90vw] flex-col border-l bg-white shadow-2xl">
+        <header className="flex items-center justify-between border-b px-4 py-3">
+          <div>
+            <h2 className="text-base font-semibold">后端运行状态</h2>
+            <div className="mt-0.5 text-xs text-gray-500">
+              {status === 'terminated'
+                ? `已退出（退出码 ${exitCode ?? 'unknown'}）`
+                : health === 'red'
+                  ? '运行中但无响应'
+                  : health === 'yellow'
+                    ? '运行中，部分系统检查未通过'
+                    : '运行正常'}
+            </div>
+          </div>
+          <button className="rounded p-1 text-gray-500 hover:bg-gray-100" onClick={onClose}>✕</button>
+        </header>
+
+        <div className="flex items-center gap-2 border-b px-4 py-2">
+          <button
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            disabled={restarting}
+            onClick={handleRestart}
+          >
+            {restarting ? '重启中…' : '重启后端'}
+          </button>
+          <button
+            className="rounded bg-gray-100 px-3 py-1 text-sm text-gray-700 hover:bg-gray-200"
+            onClick={handleCopy}
+          >
+            {copied ? '已复制 ✓' : '复制日志'}
+          </button>
+          <span className="ml-auto text-xs text-gray-400">
+            最近 {logs.length} 行
+          </span>
+        </div>
+
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-auto bg-gray-900 p-3 font-mono text-xs text-gray-100"
+        >
+          {logs.length === 0 ? (
+            <div className="text-gray-500 italic">暂无日志输出</div>
+          ) : (
+            logs.map((l, i) => (
+              <div
+                key={`${l.ts}-${i}`}
+                className={`whitespace-pre-wrap break-all leading-snug ${l.level === 'error' ? 'text-red-300' : 'text-gray-100'}`}
+              >
+                <span className="mr-2 text-gray-500">
+                  {new Date(l.ts).toISOString().slice(11, 19)}
+                </span>
+                {l.text}
+              </div>
+            ))
+          )}
+        </div>
+
+        <footer className="border-t px-4 py-2 text-xs text-gray-500">
+          后端进程退出 / 无响应时，先点「重启后端」；仍不行复制日志去 issue 反馈。
+        </footer>
+      </aside>
+    </>
+  )
+}
+
+export default BackendLogPanel

--- a/BillNote_frontend/src/components/BackendHealth/useBackendEvents.ts
+++ b/BillNote_frontend/src/components/BackendHealth/useBackendEvents.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from 'react'
+
+// 桌面端 Sidecar 健康度。监听 Tauri 侧的 backend-message / backend-error /
+// backend-terminated / backend-restarted 事件，把 stdout/stderr 缓冲成 ring buffer，
+// 同时维护进程运行状态。
+
+const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
+export type LogLevel = 'info' | 'error'
+
+export interface LogEntry {
+  level: LogLevel
+  text: string
+  ts: number
+}
+
+export type BackendStatus = 'running' | 'terminated'
+
+const MAX_LOG_LINES = 200
+
+interface BackendEvents {
+  status: BackendStatus
+  exitCode: number | null
+  logs: LogEntry[]
+  /** 调 Tauri 命令重启 sidecar */
+  restart: () => Promise<void>
+  /** 复制全部日志到剪贴板 */
+  copyLogs: () => Promise<boolean>
+  isTauri: boolean
+}
+
+export function useBackendEvents(): BackendEvents {
+  const [status, setStatus] = useState<BackendStatus>('running')
+  const [exitCode, setExitCode] = useState<number | null>(null)
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  // 用 ref 持有最新 logs 数组，append 时不被闭包陷阱卡到旧值
+  const logsRef = useRef<LogEntry[]>([])
+
+  function append(entry: LogEntry) {
+    const next = logsRef.current.concat(entry)
+    if (next.length > MAX_LOG_LINES)
+      next.splice(0, next.length - MAX_LOG_LINES)
+    logsRef.current = next
+    setLogs(next)
+  }
+
+  useEffect(() => {
+    if (!isTauri) return
+
+    let unlisteners: Array<() => void> = []
+
+    ;(async () => {
+      const { listen } = await import('@tauri-apps/api/event')
+
+      const offMsg = await listen<string>('backend-message', event => {
+        append({ level: 'info', text: stripQuotes(event.payload), ts: Date.now() })
+      })
+      const offErr = await listen<string>('backend-error', event => {
+        append({ level: 'error', text: stripQuotes(event.payload), ts: Date.now() })
+      })
+      const offTerm = await listen<number | null>('backend-terminated', event => {
+        setStatus('terminated')
+        setExitCode(event.payload ?? null)
+        append({
+          level: 'error',
+          text: `[Backend terminated] code=${event.payload ?? 'unknown'}`,
+          ts: Date.now(),
+        })
+      })
+      const offRestart = await listen('backend-restarted', () => {
+        setStatus('running')
+        setExitCode(null)
+        append({ level: 'info', text: '[Backend restarted]', ts: Date.now() })
+      })
+
+      unlisteners = [offMsg, offErr, offTerm, offRestart]
+    })()
+
+    return () => {
+      unlisteners.forEach(fn => fn())
+    }
+  }, [])
+
+  async function restart() {
+    if (!isTauri) return
+    const { invoke } = await import('@tauri-apps/api/core')
+    try {
+      await invoke('restart_backend_sidecar')
+    }
+    catch (e) {
+      append({ level: 'error', text: `[Restart failed] ${(e as Error).message ?? e}`, ts: Date.now() })
+      throw e
+    }
+  }
+
+  async function copyLogs() {
+    const text = logsRef.current
+      .map(l => `${new Date(l.ts).toISOString().slice(11, 19)} ${l.level === 'error' ? 'E' : 'I'} ${l.text}`)
+      .join('\n')
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  return { status, exitCode, logs, restart, copyLogs, isTauri }
+}
+
+// Rust 早期版本 emit 时把 stdout 包了一层 '...'，新版本已经直接 emit 原文。
+// 这里做兼容：去掉外层单引号（如果有的话）。
+function stripQuotes(s: string): string {
+  if (typeof s !== 'string') return String(s)
+  if (s.length >= 2 && s.startsWith("'") && s.endsWith("'"))
+    return s.slice(1, -1)
+  return s
+}


### PR DESCRIPTION
P1 已经把 backend-warning / backend-terminated 横幅做出来了；P2 把 lib.rs 那条 stdout/stderr/terminated 信息流真正落到一个常驻 UI 上：
- 右下角浮动状态点（绿/黄/红），轮询 /api/sys_health 决定颜色
- 点开抽屉看最近 200 行日志（ring buffer），含「重启后端」「复制日志」按钮

Rust：
- src-tauri/src/lib.rs：把 sidecar 启动抽出 spawn_backend_sidecar()， CommandChild 存进 SidecarHandle(Mutex<Option<CommandChild>>) 这个 state
- 新增 #[tauri::command] restart_backend_sidecar：kill 旧 child + 重新 spawn + emit 'backend-restarted' 给前端
- 监听任务 stdout/stderr emit 时不再用 format!("'{}'", ...) 包引号，原文直传； 前端 hook 同时兼容旧形式（兜底剥引号）

前端：
- components/BackendHealth/useBackendEvents.ts：listen 四个事件 + ring buffer (MAX 200 行) + invoke restart + clipboard 复制日志
- BackendHealthIndicator.tsx：右下角浮动状态点，5s 轮询 /api/sys_health； 连续 3 次失败或 backend-terminated 触发 → 红
- BackendLogPanel.tsx：右侧抽屉，深色 monospace 日志区 + 操作按钮
- 纯 web 环境（无 __TAURI_INTERNALS__）下静默不挂载

P3 / P4 还在路上。

<!--
PR 标题请遵循 type(scope): subject 格式，例如：
  feat(extension): 侧边栏接入思维导图
  fix(bilibili): 修正字幕优先链路在未登录态下的回退
分支命名 / 提交规范见 CONTRIBUTING.md。
-->

## 改动概述

<!-- 一句话说清这个 PR 做了什么 -->

## 为什么

<!-- 背景、关联 issue（Fixes #xxx / Refs #xxx）、用户场景 -->

## 做了什么

<!-- 关键文件、关键决策。可贴关键片段或截图 -->

## 测试方式

- [ ] `pnpm typecheck && pnpm build`（前端 / 插件）通过
- [ ] `python -m py_compile <文件>` 或本地 backend 启动验证（后端）通过
- [ ] 手动验证步骤：
  <!-- 描述如何复现验证；UI 改动请附截图 / 录屏 -->

## 回归风险

<!-- 影响面、可能受波及的功能、是否需要前后端 / 配置 同步部署 -->

## Checklist

- [ ] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [ ] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [ ] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [ ] 已自测核心流程
- [ ] 已更新相关文档（`README.md` / `CHANGELOG.md` / `CLAUDE.md` / 模块 README，如适用）
- [ ] 未夹带 secrets / `.env` / 大型二进制
- [ ] 单 PR 不跨多个工作区做无关改动
