### PR TITLE
fix: 防御 API Key 掩码污染并修复 EXE 版 .env 加载路径

### DIFF
--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -129,6 +129,10 @@ class ProviderService:
         try:
         # 过滤掉空值
             filtered_data = {k: v for k, v in data.items() if v is not None and k != 'id'}
+            # 防御掩码污染：前端展示时 api_key 被 mask_key() 处理过（如 a92f****...2d3a），
+            # 如果用户未重新输入直接保存，带星号的值不应覆盖原 key。
+            if 'api_key' in filtered_data and '*' in str(filtered_data.get('api_key', '')):
+                filtered_data.pop('api_key')
             print('更新模型供应商',filtered_data)
             update_provider(id, **filtered_data)
             # 获取更新后的供应商信息

--- a/backend/ffmpeg_helper.py
+++ b/backend/ffmpeg_helper.py
@@ -1,11 +1,41 @@
 import os
 import subprocess
+import sys
 from dotenv import load_dotenv
 
 from app.utils.logger import get_logger
 logger = get_logger(__name__)
 
-load_dotenv()
+
+def _load_dotenv_from_multiple_paths():
+    """尝试多个位置加载 .env，适配源码运行和 PyInstaller 打包场景。
+
+    PyInstaller 打包后当前工作目录是 EXE 所在目录，而源码运行时 .env
+    通常在项目根目录或 backend/ 同级。遍历常见候选路径确保能命中。
+    """
+    candidates = []
+    # 1. 当前工作目录（EXE 所在目录）
+    candidates.append(os.path.join(os.getcwd(), '.env'))
+    # 2. 本脚本所在目录（backend/）
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(os.path.join(script_dir, '.env'))
+    # 3. 项目根目录（backend/../.env）
+    candidates.append(os.path.join(script_dir, '..', '.env'))
+    # 4. PyInstaller 打包后的 _internal/ 子目录
+    if getattr(sys, 'frozen', False):
+        exe_dir = os.path.dirname(sys.executable)
+        candidates.append(os.path.join(exe_dir, '_internal', '.env'))
+
+    for path in candidates:
+        normalized = os.path.normpath(path)
+        if os.path.isfile(normalized):
+            load_dotenv(normalized)
+            return
+    # 都没找到，fallback 到默认行为（从 CWD 找）
+    load_dotenv()
+
+
+_load_dotenv_from_multiple_paths()
 def check_ffmpeg_exists() -> bool:
     """
     检查 ffmpeg 是否可用。优先使用 FFMPEG_BIN_PATH 环境变量指定的路径。


### PR DESCRIPTION
## 修复内容

### 1. 防御 API Key 掩码污染（backend/app/services/provider.py）

**问题**：前端编辑供应商时，/get_provider_by_id 返回的 pi_key 被 mask_key() 处理为掩码格式（如 92f****...2d3a）。用户未重新输入直接保存时，带星号的值被写回数据库，导致实际 key 损坏（调用时 401 Unauthorized）。

**修复**：在 ProviderService.update_provider() 中，若传入的 pi_key 包含 '*' 字符，自动跳过该字段，保留数据库中的原值。

### 2. 修复 EXE 桌面版 .env 加载路径（backend/ffmpeg_helper.py）

**问题**：load_dotenv() 默认只从当前工作目录（CWD）查找 .env。PyInstaller 打包后，CWD 为 EXE 所在目录（如 C:\Users\...\BiliNote\），而 .env 实际位于 _internal/.env，导致 FFMPEG_BIN_PATH 等环境变量始终加载失败。

**修复**：新增 _load_dotenv_from_multiple_paths()，按以下优先级遍历候选路径：
1. 当前工作目录（EXE 同级 .env）
2. 脚本所在目录（ackend/.env）
3. 项目根目录（ackend/../.env）
4. PyInstaller _internal/ 子目录

找到第一个存在的 .env 即加载，否则 fallback 到默认行为。

---

## 影响范围

- 所有通过前端「模型供应商」页面编辑过 API Key 的用户（防止 key 被意外覆盖）
- Windows EXE 桌面端用户（确保 FFmpeg 等环境变量正确加载）

## 测试

- [x] 编辑供应商时不修改 api_key，保存后数据库原值不变
- [x] 重新输入完整 api_key 后保存，数据库正确更新
- [x] EXE 版重启后 FFMPEG_BIN_PATH 正确加载