### PR TITLE
feat(extension): 侧边栏与 popup 用视频标题替代链接显示

### DIFF
--- a/BillNote_extension/src/background/main.ts
+++ b/BillNote_extension/src/background/main.ts
@@ -56,7 +56,7 @@ async function upsertTask(record: TaskRecord) {
 
 // ---------- 启动任务 ----------
 
-async function startTask(url: string): Promise<{ ok: boolean, taskId?: string, error?: string }> {
+async function startTask(url: string, title?: string): Promise<{ ok: boolean, taskId?: string, error?: string }> {
   const platform = detectPlatform(url)
   if (!platform)
     return { ok: false, error: '当前链接不是支持的视频平台' }
@@ -107,6 +107,7 @@ async function startTask(url: string): Promise<{ ok: boolean, taskId?: string, e
       message: '已提交',
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      title,
     })
     return { ok: true, taskId: body.data.task_id }
   }
@@ -129,8 +130,8 @@ async function openSidePanelInTab(tabId?: number) {
 
 // ---------- 消息桥 ----------
 
-onMessage<{ url: string }, 'bilinote-start'>('bilinote-start', async ({ data, sender }) => {
-  const result = await startTask(data.url)
+onMessage<{ url: string; title?: string }, 'bilinote-start'>('bilinote-start', async ({ data, sender }) => {
+  const result = await startTask(data.url, data.title)
   // 成功就把侧边栏拉起来给用户看进度
   if (result.ok)
     await openSidePanelInTab(sender?.tabId)
@@ -168,7 +169,7 @@ browser.contextMenus?.onClicked.addListener(async (info, tab) => {
   const url = info.linkUrl || tab?.url
   if (!url)
     return
-  const result = await startTask(url)
+  const result = await startTask(url, tab?.title)
   if (result.ok)
     await openSidePanelInTab(tab?.id)
   else

--- a/BillNote_extension/src/contentScripts/views/App.vue
+++ b/BillNote_extension/src/contentScripts/views/App.vue
@@ -19,6 +19,7 @@ async function trigger() {
     const res = await sendMessage('bilinote-start', {
       url: window.location.href,
       platform,
+      title: document.title,
     }, 'background')
     const ok = res && (res as any).ok
     toast.value = ok

--- a/BillNote_extension/src/logic/types.ts
+++ b/BillNote_extension/src/logic/types.ts
@@ -79,6 +79,8 @@ export interface TaskRecord {
   createdAt: number
   updatedAt: number
   result?: NoteResult
+  // 从浏览器 tab.title 抓取，任务完成前用来替代 videoUrl 显示
+  title?: string
 }
 
 // 与 backend/app/gpt/prompt_builder.py note_styles 一一对齐

--- a/BillNote_extension/src/popup/Popup.vue
+++ b/BillNote_extension/src/popup/Popup.vue
@@ -43,6 +43,7 @@ async function poll(taskId: string) {
       createdAt: activeTask.value?.createdAt ?? Date.now(),
       updatedAt: Date.now(),
       result: res.result ?? activeTask.value?.result,
+      title: activeTask.value?.title,
     })
     if (res.status !== 'SUCCESS' && res.status !== 'FAILED')
       pollTimer = setTimeout(() => poll(taskId), 3000)
@@ -94,6 +95,7 @@ async function start() {
       message: '已提交',
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      title: tabTitle.value || undefined,
     })
     poll(task_id)
     // 提交后顺手把侧边栏拉起来，免得用户来回切窗口
@@ -142,7 +144,10 @@ function selectTask(id: string) {
 }
 
 const activeCover = computed(() => activeTask.value?.result?.audio_meta?.cover_url as string | undefined)
-const activeTitle = computed(() => (activeTask.value?.result?.audio_meta?.title as string | undefined) || tabTitle.value)
+const activeTitle = computed(() =>
+  (activeTask.value?.result?.audio_meta?.title as string | undefined)
+  || activeTask.value?.title
+  || tabTitle.value)
 
 function fmtTime(ts?: number) {
   if (!ts)
@@ -331,8 +336,8 @@ onUnmounted(() => {
           :class="{ 'bg-blue-50': t.taskId === activeTaskId }"
           @click="selectTask(t.taskId)"
         >
-          <span class="truncate flex-1" :title="t.videoUrl">
-            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.videoUrl }}
+          <span class="truncate flex-1" :title="t.title || t.videoUrl">
+            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.title || t.videoUrl }}
           </span>
           <span class="text-gray-500 shrink-0">{{ t.status }}</span>
         </li>

--- a/BillNote_extension/src/sidepanel/Sidepanel.vue
+++ b/BillNote_extension/src/sidepanel/Sidepanel.vue
@@ -41,6 +41,7 @@ async function poll(taskId: string) {
         message: res.message,
         result: res.result ?? cur.result,
         updatedAt: Date.now(),
+        title: cur.title,
       })
     }
     if (res.status !== 'SUCCESS' && res.status !== 'FAILED')
@@ -89,7 +90,10 @@ function downloadMarkdown() {
 }
 
 const activeTitle = computed(() =>
-  (activeTask.value?.result?.audio_meta as { title?: string } | undefined)?.title || activeTask.value?.videoUrl || '')
+  (activeTask.value?.result?.audio_meta as { title?: string } | undefined)?.title
+  || activeTask.value?.title
+  || activeTask.value?.videoUrl
+  || '')
 
 const activeCover = computed(() =>
   (activeTask.value?.result?.audio_meta as { cover_url?: string } | undefined)?.cover_url)
@@ -140,8 +144,8 @@ onUnmounted(() => {
           :class="{ 'bg-white border': t.taskId === activeTaskId }"
           @click="selectTask(t.taskId)"
         >
-          <span class="truncate flex-1" :title="t.videoUrl">
-            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.videoUrl }}
+          <span class="truncate flex-1" :title="t.title || t.videoUrl">
+            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.title || t.videoUrl }}
           </span>
           <span class="text-gray-400 shrink-0">{{ STAGE_LABELS[t.status] || t.status }}</span>
         </li>
@@ -170,7 +174,7 @@ onUnmounted(() => {
           class="text-sm font-medium leading-tight line-clamp-1 break-all flex-1 min-w-0 hover:text-blue-600"
           :href="activeTask.videoUrl"
           target="_blank"
-          :title="activeTask.videoUrl"
+          :title="activeTitle || activeTask.videoUrl"
         >{{ activeTitle }}</a>
         <span
           v-if="isDone"


### PR DESCRIPTION
## 背景

在任务未完成的早期阶段（PENDING / DOWNLOADING 等），侧边栏和 popup 的历史列表、当前任务标题只能回退到 `videoUrl`，用户看到的是一长串链接，难以辨认当前是哪个视频。

## 改动

- `TaskRecord` 新增 `title?: string` 字段，用于存储浏览器标签页标题
- `popup` 创建任务时保存 `tab.title`
- `background` 的 `startTask()` 接收可选 `title` 参数
  - 右键菜单启动时传入 `tab?.title`
  - 悬浮按钮（content script）启动时传入 `document.title`
- 显示优先级统一为：`result.audio_meta.title` > `title` > `videoUrl`
  - 任务完成后后端返回的纯净标题仍优先
  - 未完成时显示浏览器标签页标题（带平台后缀，如 `xxx - YouTube`）
  - 兜底仍保留链接，确保任何情况下都有内容可显示
- 修改范围覆盖 `Sidepanel.vue`、`Popup.vue`、`background/main.ts`、`contentScripts/views/App.vue`、`logic/types.ts`

## 测试

- `pnpm typecheck` 通过
- `pnpm build` 通过
- 在 Bilibili、YouTube、抖音、快手视频页提交任务，侧边栏和 popup 均显示标题而非链接

## 回归风险

- 低。仅涉及扩展前端展示层，无后端协议变更
- `title` 为可选字段，旧数据无此字段时行为与之前一致（回退到 `videoUrl`）
