### PR TITLE
ui(frontend): 新增 Logo 首页入口并优化窄屏表单

### DIFF
--- a/BillNote_extension/src/logic/open-note-page.ts
+++ b/BillNote_extension/src/logic/open-note-page.ts
@@ -1,0 +1,18 @@
+export type SidepanelViewMode = 'markdown' | 'mindmap' | 'chat'
+
+export function buildSidepanelPageUrl(taskId?: string, view?: SidepanelViewMode): string {
+  const params = new URLSearchParams()
+  if (taskId)
+    params.set('taskId', taskId)
+  if (view)
+    params.set('view', view)
+
+  const query = params.toString()
+  return browser.runtime.getURL(`dist/sidepanel/index.html${query ? `?${query}` : ''}`)
+}
+
+export async function openSidepanelPage(taskId?: string, view?: SidepanelViewMode) {
+  await browser.tabs.create({
+    url: buildSidepanelPageUrl(taskId, view),
+  })
+}

--- a/BillNote_extension/src/popup/Popup.vue
+++ b/BillNote_extension/src/popup/Popup.vue
@@ -4,6 +4,7 @@ import { detectPlatform } from '~/logic/platform'
 import { settings, settingsReady, tasks, tasksReady, upsertTask } from '~/logic/storage'
 import { generateNote, getTaskStatus, resolveImageUrl } from '~/logic/api'
 import { fetchBilibiliSubtitle } from '~/logic/bilibili-subtitle'
+import { openSidepanelPage } from '~/logic/open-note-page'
 import { NOTE_FORMATS, NOTE_STYLES, type NoteFormat, type TaskRecord } from '~/logic/types'
 
 const tabUrl = ref<string>('')
@@ -113,6 +114,11 @@ function openOptions() {
   browser.runtime.openOptionsPage()
 }
 
+async function openCurrentNotePage() {
+  const taskId = activeTaskId.value || tasks.value?.[0]?.taskId
+  await openSidepanelPage(taskId, 'markdown')
+}
+
 function toggleFormat(value: NoteFormat, checked: boolean) {
   const cur = settings.value.formats || []
   settings.value.formats = checked
@@ -176,7 +182,13 @@ onUnmounted(() => {
   <main class="w-[400px] p-3 text-sm text-gray-800 flex flex-col gap-3 bg-white">
     <header class="flex items-center justify-between">
       <div class="flex items-center gap-2">
-        <span class="font-semibold text-base">BiliNote</span>
+        <button
+          class="font-semibold text-base rounded px-1 -ml-1 hover:text-blue-600 hover:bg-blue-50"
+          title="在新标签页打开当前笔记预览"
+          @click="openCurrentNotePage"
+        >
+          打开笔记
+        </button>
         <PlatformBadge :platform="platform" />
       </div>
       <button class="text-xs text-gray-500 hover:text-gray-800" @click="openOptions">设置</button>

--- a/BillNote_extension/src/sidepanel/Sidepanel.vue
+++ b/BillNote_extension/src/sidepanel/Sidepanel.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { getTaskStatus, resolveImageUrl } from '~/logic/api'
+import { openSidepanelPage, type SidepanelViewMode } from '~/logic/open-note-page'
 import { tasks, tasksReady, settingsReady, upsertTask } from '~/logic/storage'
 import type { TaskRecord } from '~/logic/types'
-
-type ViewMode = 'markdown' | 'mindmap' | 'chat'
 
 const activeTaskId = ref<string>('')
 const activeTask = computed<TaskRecord | undefined>(() => tasks.value?.find(t => t.taskId === activeTaskId.value))
 const errorMsg = ref('')
-const viewMode = ref<ViewMode>('markdown')
+const viewMode = ref<SidepanelViewMode>('markdown')
 const showHistory = ref(false)
 
 const isDone = computed(() => activeTask.value?.status === 'SUCCESS')
@@ -69,6 +68,10 @@ function openOptions() {
   browser.runtime.openOptionsPage()
 }
 
+async function openCurrentNotePage() {
+  await openSidepanelPage(activeTaskId.value || undefined, viewMode.value)
+}
+
 async function copyMarkdown() {
   const md = activeTask.value?.result?.markdown
   if (md)
@@ -100,7 +103,15 @@ const activeCover = computed(() =>
 
 onMounted(async () => {
   await Promise.all([settingsReady, tasksReady])
-  const latest = tasks.value?.[0]
+  const params = new URLSearchParams(window.location.search)
+  const requestedTaskId = params.get('taskId') || ''
+  const requestedView = params.get('view')
+  const validViews: SidepanelViewMode[] = ['markdown', 'mindmap', 'chat']
+
+  if (validViews.includes(requestedView as SidepanelViewMode))
+    viewMode.value = requestedView as SidepanelViewMode
+
+  const latest = tasks.value?.find(t => t.taskId === requestedTaskId) || tasks.value?.[0]
   if (latest) {
     activeTaskId.value = latest.taskId
     if (latest.status !== 'SUCCESS' && latest.status !== 'FAILED')
@@ -118,7 +129,13 @@ onUnmounted(() => {
   <main class="w-full h-full flex flex-col bg-white text-sm text-gray-800">
     <!-- 顶栏：极简 -->
     <header class="flex items-center justify-between px-3 py-2 border-b shrink-0">
-      <div class="font-semibold">BiliNote</div>
+      <button
+        class="font-semibold rounded px-1 -ml-1 hover:text-blue-600 hover:bg-blue-50"
+        title="在新标签页打开当前笔记预览"
+        @click="openCurrentNotePage"
+      >
+        打开笔记
+      </button>
       <div class="flex items-center gap-1">
         <button
           v-if="(tasks?.length ?? 0) > 0"

--- a/BillNote_frontend/src/components/BrandLogo.tsx
+++ b/BillNote_frontend/src/components/BrandLogo.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom'
+import logo from '@/assets/icon.svg'
+
+interface BrandLogoProps {
+  to?: string
+}
+
+export function BrandLogo({ to = '/' }: BrandLogoProps) {
+  return (
+    <Link to={to} className="flex items-center gap-2">
+      <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-2xl">
+        <img src={logo} alt="logo" className="h-full w-full object-contain" />
+      </div>
+      <div className="text-2xl font-bold text-gray-800">BiliNote</div>
+    </Link>
+  )
+}

--- a/BillNote_frontend/src/components/ui/scroll-area.tsx
+++ b/BillNote_frontend/src/components/ui/scroll-area.tsx
@@ -11,12 +11,12 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn('relative', className)}
+      className={cn('relative overflow-hidden', className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full max-w-full min-w-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/BillNote_frontend/src/layouts/HomeLayout.tsx
+++ b/BillNote_frontend/src/layouts/HomeLayout.tsx
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom'
 import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable'
 import { ScrollArea } from "@/components/ui/scroll-area.tsx"
 import type { ImperativePanelHandle } from 'react-resizable-panels'
-import logo from '@/assets/icon.svg'
+import { BrandLogo } from '@/components/BrandLogo'
 
 interface IProps {
   NoteForm: React.ReactNode
@@ -42,12 +42,7 @@ const HomeLayout: FC<IProps> = ({ NoteForm, Preview, History }) => {
         >
           <aside className="flex h-full flex-col overflow-hidden border-r border-neutral-200 bg-white">
             <header className="flex h-16 items-center justify-between px-6">
-              <div className="flex items-center gap-2">
-                <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-2xl">
-                  <img src={logo} alt="logo" className="h-full w-full object-contain" />
-                </div>
-                <div className="text-2xl font-bold text-gray-800">BiliNote</div>
-              </div>
+              <BrandLogo />
               <div className="flex items-center gap-1">
                 <TooltipProvider>
                   <Tooltip>

--- a/BillNote_frontend/src/layouts/HomeLayout.tsx
+++ b/BillNote_frontend/src/layouts/HomeLayout.tsx
@@ -73,7 +73,7 @@ const HomeLayout: FC<IProps> = ({ NoteForm, Preview, History }) => {
                 </TooltipProvider>
               </div>
             </header>
-            <ScrollArea className="flex-1 overflow-auto">
+            <ScrollArea className="min-h-0 flex-1">
               <div className="p-4">{NoteForm}</div>
             </ScrollArea>
           </aside>
@@ -130,7 +130,7 @@ const HomeLayout: FC<IProps> = ({ NoteForm, Preview, History }) => {
                 </Tooltip>
               </TooltipProvider>
             </header>
-            <ScrollArea className="flex-1 overflow-auto">
+            <ScrollArea className="min-h-0 flex-1">
               <div>{History}</div>
             </ScrollArea>
           </aside>

--- a/BillNote_frontend/src/layouts/SettingLayout.tsx
+++ b/BillNote_frontend/src/layouts/SettingLayout.tsx
@@ -7,7 +7,7 @@ import {
 import { Link, Outlet } from 'react-router-dom'
 import { SlidersHorizontal } from 'lucide-react'
 import React from 'react'
-import logo from '@/assets/icon.svg'
+import { BrandLogo } from '@/components/BrandLogo'
 
 interface ISettingLayoutProps {
   Menu: React.ReactNode
@@ -25,12 +25,7 @@ const SettingLayout = ({ Menu }: ISettingLayoutProps) => {
         <aside className="flex w-[300px] flex-col border-r border-neutral-200 bg-white">
           {/* Header */}
           <header className="flex h-16 items-center justify-between px-6">
-            <div className="flex items-center gap-2">
-              <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-2xl">
-                <img src={logo} alt="logo" className="h-full w-full object-contain" />
-              </div>
-              <div className="text-2xl font-bold text-gray-800">BiliNote</div>
-            </div>
+            <BrandLogo />
             <div>
               <TooltipProvider>
                 <Tooltip>

--- a/BillNote_frontend/src/pages/HomePage/components/NoteForm.tsx
+++ b/BillNote_frontend/src/pages/HomePage/components/NoteForm.tsx
@@ -263,10 +263,10 @@ const NoteForm = () => {
     const label = generating ? '正在生成…' : editing ? '重新生成' : '生成笔记'
 
     return (
-      <div className="flex gap-2">
+      <div className={editing ? 'grid grid-cols-2 gap-2' : 'flex'}>
         <Button
           type="submit"
-          className={!editing ? 'w-full' : 'w-2/3' + ' bg-primary'}
+          className="w-full"
           disabled={generating}
         >
           {generating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -274,7 +274,7 @@ const NoteForm = () => {
         </Button>
 
         {editing && (
-          <Button type="button" variant="outline" className="w-1/3" onClick={handleCreateNew}>
+          <Button type="button" variant="outline" className="w-full" onClick={handleCreateNew}>
             <Plus className="mr-2 h-4 w-4" />
             新建笔记
           </Button>
@@ -489,14 +489,14 @@ const NoteForm = () => {
               )}
             />
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-2 gap-3">
               {/* 采样间隔 */}
               <FormField
                 control={form.control}
                 name="video_interval"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>采样间隔（秒）</FormLabel>
+                  <FormItem className="min-w-0">
+                    <FormLabel className="block truncate whitespace-nowrap">采样间隔（秒）</FormLabel>
                     <Input disabled={!videoUnderstandingEnabled} type="number" {...field} />
                     <FormMessage />
                   </FormItem>
@@ -507,23 +507,23 @@ const NoteForm = () => {
                 control={form.control}
                 name="grid_size"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>拼图尺寸（列 × 行）</FormLabel>
-                    <div className="flex items-center space-x-2">
+                  <FormItem className="min-w-0">
+                    <FormLabel className="block truncate whitespace-nowrap">拼图尺寸（列×行）</FormLabel>
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
                       <Input
                         disabled={!videoUnderstandingEnabled}
                         type="number"
                         value={field.value?.[0] || 3}
                         onChange={e => field.onChange([+e.target.value, field.value?.[1] || 3])}
-                        className="w-16"
+                        className="min-w-0 text-center"
                       />
-                      <span>x</span>
+                      <span className="text-center text-neutral-600">x</span>
                       <Input
                         disabled={!videoUnderstandingEnabled}
                         type="number"
                         value={field.value?.[1] || 3}
                         onChange={e => field.onChange([field.value?.[0] || 3, +e.target.value])}
-                        className="w-16"
+                        className="min-w-0 text-center"
                       />
                     </div>
                     <FormMessage />


### PR DESCRIPTION
## 改动概述

新增 Web 端顶部 Logo / 标题的首页入口，并补齐浏览器插件中“打开笔记”的快捷入口；同时优化窄屏下左侧表单滚动、按钮宽度和视频理解配置项换行挤压的问题。

把用户实际会点击的 **Logo / 标题区域** 做成一致、明确的导航入口：在笔记页和设置页都保持同样的 Logo 尺寸、间距和返回首页行为，避免不同页面顶部入口表现不一致。


## 为什么

实际使用时有几个体验问题比较明显：

1. **Web 端 Logo / 标题缺少稳定的首页入口**
   笔记页和设置页顶部 Logo / 标题的尺寸、位置和可点击行为不一致，部分页面缺少点击 Logo 返回首页的入口。用户通常会自然地把左上角 Logo 当成“回首页”的入口，如果有的页面能点、有的页面不能点，或者样式不一致，就会造成困惑。

2. **插件里缺少直接打开当前笔记页的入口**
   在浏览器插件的 Popup / Sidepanel 里查看任务时，如果想跳到完整笔记预览页，需要有一个更直接、更稳定的入口，而不是让用户自己找链接或重新进入 Web 页面。

3. **窄屏表单布局有细节问题**
   在较窄宽度下，左侧表单会出现双滚动条；编辑状态下“重新生成 / 新建笔记”按钮宽度不一致；视频理解里的“采样间隔”和“拼图尺寸”标签容易换行并挤压输入框。这些都会让移动端或窄窗口下的操作显得不稳定。

## 做了什么

- Web 端 Logo 入口
  - 新增 `BrandLogo` 组件，统一封装 Logo / 标题展示和点击返回首页行为。
  - `HomeLayout` 和 `SettingLayout` 复用同一个 Logo 入口，保证尺寸、间距、位置和交互一致。

- 浏览器插件打开笔记入口
  - 新增 `open-note-page` 工具，统一生成并打开当前笔记预览页。
  - Sidepanel 顶部新增“打开笔记”，可打开当前任务对应的笔记预览，并保留当前任务与视图参数。
  - Popup 顶部新增“打开笔记”，优先打开当前任务，缺失时回退到最近任务。

- 窄屏表单布局优化
  - 调整 ScrollArea，避免 Radix ScrollArea 和浏览器原生滚动条叠加形成双滚动条。
  - 编辑已有笔记时，“重新生成 / 新建笔记”按钮等宽显示。
  - 视频理解配置中，“采样间隔”和“拼图尺寸（列×行）”保持同一行；长标签截断不换行，避免挤压输入框。

## 测试方式

- [x] `pnpm build`（Web 前端）通过
- [x] `pnpm typecheck && pnpm build`（浏览器插件）通过
- [x] 后端验证不适用：本 PR 不涉及 backend 代码
- [x] 手动验证步骤：
  - 打开 Web 笔记页与设置页，确认 Logo / 标题尺寸、位置一致，点击后返回首页。
  - 在窄屏或左侧较窄布局下确认左侧表单不再出现双滚动条。
  - 编辑已有笔记时确认“重新生成 / 新建笔记”等宽显示。
  - 开启视频理解后确认“采样间隔”和“拼图尺寸（列×行）”保持同一行，标签不换行且输入框可完整操作。
  - 构建并加载浏览器插件，确认 Popup / Sidepanel 顶部“打开笔记”可打开当前插件预览页。

## 回归风险

影响范围集中在 Web 前端布局和浏览器插件 Popup / Sidepanel 顶部入口：

- Web 端：`HomeLayout`、`SettingLayout`、Logo / 标题入口、左侧表单滚动区域和视频理解表单布局。
- 插件端：Popup / Sidepanel 顶部“打开笔记”入口，以及新标签页打开当前笔记预览页时携带的 query 参数。

不涉及后端接口、数据库迁移或配置变更。主要风险是不同浏览器对扩展页 URL 的打开行为可能存在细微差异，需要在插件环境中重点确认“打开笔记”入口。

## Checklist

- [x] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [x] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [x] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [x] 已自测核心流程
- [x] 已更新相关文档（不适用：本 PR 为 UI/交互优化，不涉及文档）
- [x] 未夹带 secrets / `.env` / 大型二进制
- [x] 单 PR 不跨多个工作区做无关改动



