### PR TITLE
fix(youtube): 支持 Shorts 链接

### DIFF
--- a/backend/app/utils/url_parser.py
+++ b/backend/app/utils/url_parser.py
@@ -23,8 +23,8 @@ def extract_video_id(url: str, platform: str) -> Optional[str]:
         return f"BV{match.group(1)}" if match else None
 
     elif platform == "youtube":
-        # 匹配 v=xxxxx 或 youtu.be/xxxxx，ID 长度通常为 11
-        match = re.search(r"(?:v=|youtu\.be/)([0-9A-Za-z_-]{11})", url)
+        # 匹配 v=xxxxx、youtu.be/xxxxx 或 shorts/xxxxx，ID 长度通常为 11
+        match = re.search(r"(?:v=|youtu\.be/|shorts/)([0-9A-Za-z_-]{11})", url)
         return match.group(1) if match else None
 
     elif platform == "douyin":

--- a/backend/app/validators/video_url_validator.py
+++ b/backend/app/validators/video_url_validator.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 SUPPORTED_PLATFORMS = {
     "bilibili": r"(https?://)?(www\.)?bilibili\.com/video/[a-zA-Z0-9]+",
-    "youtube": r"(https?://)?(www\.)?(youtube\.com/watch\?v=|youtu\.be/)[\w\-]+",
+    "youtube": r"(https?://)?(www\.)?(youtube\.com/(watch\?v=|shorts/)|youtu\.be/)[\w\-]+",
     "douyin": "douyin",
     "kuaishou": "kuaishou"
 }

--- a/backend/tests/test_video_url_support.py
+++ b/backend/tests/test_video_url_support.py
@@ -1,0 +1,50 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_module(name, relative_path):
+    module_path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"{name} module spec not found")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+url_parser = _load_module("url_parser", pathlib.Path("app") / "utils" / "url_parser.py")
+video_url_validator = _load_module(
+    "video_url_validator",
+    pathlib.Path("app") / "validators" / "video_url_validator.py",
+)
+
+
+class TestVideoUrlSupport(unittest.TestCase):
+    def test_extract_youtube_video_id_from_supported_url_shapes(self):
+        expected_id = "dQw4w9WgXcQ"
+
+        cases = [
+            f"https://www.youtube.com/watch?v={expected_id}",
+            f"https://youtu.be/{expected_id}",
+            f"https://www.youtube.com/shorts/{expected_id}",
+        ]
+
+        for url in cases:
+            with self.subTest(url=url):
+                self.assertEqual(
+                    url_parser.extract_video_id(url, "youtube"),
+                    expected_id,
+                )
+
+    def test_accepts_youtube_shorts_url(self):
+        url = "https://www.youtube.com/shorts/dQw4w9WgXcQ"
+
+        self.assertTrue(video_url_validator.is_supported_video_url(url))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动概述

支持后端识别 YouTube Shorts 链接，并从 Shorts URL 中提取视频 ID。

## 为什么

BiliNote 已支持 YouTube 视频链接，但后端当前只识别 `watch?v=` 和 `youtu.be/` 两种链接形态。现在 YouTube Shorts 链接非常常见，例如 `https://www.youtube.com/shorts/<id>`，这类链接可能会在 URL 校验阶段被拒绝，或在后续字幕 / 视频处理链路中无法提取 video id。

## 做了什么

- 在 `is_supported_video_url` 中允许 `youtube.com/shorts/<id>` 链接
- 在 `extract_video_id` 中支持从 Shorts URL 提取 YouTube video id
- 新增单元测试，覆盖 `watch?v=`、`youtu.be/`、`shorts/` 三种 YouTube URL 形态

## 测试方式

- [x] `python -m py_compile backend/app/utils/url_parser.py backend/app/validators/video_url_validator.py backend/tests/test_video_url_support.py`
- [x] `python -m unittest backend.tests.test_video_url_support`
- [x] `python -m unittest backend.tests.test_video_url_support backend.tests.test_note_helper`

手动验证过以下输入会通过后端 URL 校验，并提取出正确的 video id：

```text
https://www.youtube.com/shorts/dQw4w9WgXcQ
  supported: True
  video_id : dQw4w9WgXcQ

https://youtube.com/shorts/dQw4w9WgXcQ?feature=share
  supported: True
  video_id : dQw4w9WgXcQ
```

补充说明：本地执行 `python -m unittest discover backend/tests` 时，当前有一个与本次改动无关的既有失败：`test_task_serial_executor`。本次没有完成完整「生成笔记」端到端验证，因为本地缺少完整后端运行依赖 / 模型与供应商配置。

## 回归风险

风险较低。本次改动只扩展 YouTube URL 的接受范围和 video id 提取正则；已有的 `watch?v=` 和 `youtu.be/` 链接形态已通过测试覆盖。