### PR TITLE
fix(frontend): 同步关于页版本号

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,6 +42,16 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Resolve app version
+        id: app-version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
@@ -50,6 +60,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_APP_VERSION=${{ steps.app-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/BillNote_frontend/Dockerfile
+++ b/BillNote_frontend/Dockerfile
@@ -5,6 +5,10 @@
 ARG BASE_REGISTRY=docker.io
 FROM ${BASE_REGISTRY}/library/node:20-alpine AS builder
 
+# 可由发布 workflow 从 git tag 注入，用于前端 About 页展示版本；未传时由 Vite 回退读取 tauri.conf.json。
+ARG VITE_APP_VERSION=
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
+
 # pnpm pin 到 9.x：lockfile 是 v9 生成；pnpm 11 要求 Node 22+ 与 node:20 不兼容
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 

--- a/BillNote_frontend/src/pages/SettingPage/about.tsx
+++ b/BillNote_frontend/src/pages/SettingPage/about.tsx
@@ -8,6 +8,7 @@ import logo from '@/assets/icon.svg'
 import wechatQr from '@/assets/wechat.png'
 
 export default function AboutPage() {
+  const appVersion = __APP_VERSION__
   const images = [
     'https://common-1304618721.cos.ap-chengdu.myqcloud.com/20250504102850.png',
     'https://common-1304618721.cos.ap-chengdu.myqcloud.com/20250504103028.png',
@@ -27,7 +28,7 @@ export default function AboutPage() {
               height={50}
               className="rounded-lg"
             />
-            <h1 className="text-4xl font-bold">BiliNote v2.0.0</h1>
+            <h1 className="text-4xl font-bold">BiliNote v{appVersion}</h1>
           </div>
           <p className="text-muted-foreground mb-6 text-xl italic">
             AI 视频笔记生成工具 让 AI 为你的视频做笔记

--- a/BillNote_frontend/src/vite-env.d.ts
+++ b/BillNote_frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/BillNote_frontend/vite.config.ts
+++ b/BillNote_frontend/vite.config.ts
@@ -1,10 +1,24 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import tailwindcss from '@tailwindcss/vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function readAppVersion() {
+  const fallbackVersion = '0.0.0'
+
+  try {
+    const tauriConfigPath = path.resolve(__dirname, 'src-tauri/tauri.conf.json')
+    const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, 'utf-8')) as { version?: string }
+    return tauriConfig.version || fallbackVersion
+  }
+  catch {
+    return fallbackVersion
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -14,9 +28,13 @@ export default defineConfig(({ mode }) => {
 
   const apiBaseUrl = env.VITE_API_BASE_URL || 'http://127.0.0.1:8483'
   const port = parseInt(env.VITE_FRONTEND_PORT || '3015', 10)
+  const appVersion = env.VITE_APP_VERSION || process.env.VITE_APP_VERSION || readAppVersion()
 
   return {
     base: './',
+    define: {
+      __APP_VERSION__: JSON.stringify(appVersion),
+    },
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {

--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -35,6 +35,10 @@ COPY ./backend /tmp/backend
 ARG BASE_REGISTRY=docker.io
 FROM ${BASE_REGISTRY}/library/node:20-alpine AS frontend-builder
 
+# 可由发布 workflow 从 git tag 注入，用于前端 About 页展示版本；未传时由 Vite 回退读取 tauri.conf.json。
+ARG VITE_APP_VERSION=
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
+
 # pnpm 版本 pin 到 9 系列：
 # - lockfile (BillNote_frontend/pnpm-lock.yaml) 是 lockfileVersion '9.0'，由 pnpm 9 生成
 # - pnpm 11+ 要求 Node 22+，与 node:20 不兼容（ERR_UNKNOWN_BUILTIN_MODULE）


### PR DESCRIPTION
## 改动概述

让前端关于页版本号从构建时注入的应用版本读取，不再在页面中硬编码 `BiliNote v2.0.0`。

## 为什么

About 页版本号此前写死为 `2.0.0`，发版或 Docker 镜像构建时容易与实际应用版本不一致。

## 做了什么

- 在 Vite 构建中注入 `__APP_VERSION__`。
- 默认从 `BillNote_frontend/src-tauri/tauri.conf.json` 读取版本号。
- 支持通过 `VITE_APP_VERSION` 覆盖构建版本。
- 更新 Dockerfile / Docker 构建 workflow，确保镜像构建也能传入版本号。
- About 页改为展示 `BiliNote v{appVersion}`。

## 测试方式

- [x] 前端构建通过：`CI=true npx -y pnpm@9.15.0 install --frozen-lockfile && npx -y pnpm@9.15.0 build`。当前前端包未提供 `typecheck` script，按构建验证处理。
- [x] 后端验证：N/A，本 PR 不涉及后端 Python 代码。
- [x] 手动验证步骤：用户已基于 `fix/frontend-about-version` 分支打包/运行验证，About 页版本显示修复正常。

## 回归风险

风险较低。改动集中在前端构建时版本注入和 About 页展示；若 `tauri.conf.json` 读取失败，会回退为 `0.0.0`。Docker 构建路径新增版本参数，需关注 CI/Docker 构建是否正常传递。

## Checklist

- [x] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [x] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [x] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [x] 已自测核心流程
- [x] 已更新相关文档（N/A：本 PR 不涉及 README / CHANGELOG / CLAUDE.md / 模块 README 变更）
- [x] 未夹带 secrets / `.env` / 大型二进制
- [x] 单 PR 不跨多个工作区做无关改动
