### PR TITLE
fix(extension): 完善任务标题展示和思维导图高清导出

### DIFF
--- a/BillNote_extension/src/background/main.ts
+++ b/BillNote_extension/src/background/main.ts
@@ -3,6 +3,7 @@ import type { Settings, TaskRecord } from '~/logic/types'
 import { DEFAULT_SETTINGS, MAX_TASKS, SETTINGS_KEY, TASKS_KEY } from '~/logic/constants'
 import { detectPlatform } from '~/logic/platform'
 import { fetchBilibiliSubtitle } from '~/logic/bilibili-subtitle'
+import { normalizeVideoTitle } from '~/logic/task-display'
 
 // only on dev mode
 if (import.meta.hot) {
@@ -58,6 +59,7 @@ async function upsertTask(record: TaskRecord) {
 
 async function startTask(url: string, title?: string): Promise<{ ok: boolean, taskId?: string, error?: string }> {
   const platform = detectPlatform(url)
+  const displayTitle = normalizeVideoTitle(title)
   if (!platform)
     return { ok: false, error: '当前链接不是支持的视频平台' }
 
@@ -107,7 +109,7 @@ async function startTask(url: string, title?: string): Promise<{ ok: boolean, ta
       message: '已提交',
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      title,
+      title: displayTitle,
     })
     return { ok: true, taskId: body.data.task_id }
   }

--- a/BillNote_extension/src/components/MindMap.vue
+++ b/BillNote_extension/src/components/MindMap.vue
@@ -1,32 +1,181 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { Transformer } from 'markmap-lib'
 import { Markmap } from 'markmap-view'
 import { absolutizeMarkdownImages, stripSourceLink } from '~/logic/api'
 
 const props = defineProps<{ markdown: string }>()
 
+const wrapRef = ref<HTMLDivElement | null>(null)
 const svgRef = ref<SVGSVGElement | null>(null)
 let mm: Markmap | null = null
+let resizeObserver: ResizeObserver | null = null
 const transformer = new Transformer()
+const MIN_EXPORT_FONT_PX = 256
+const MIN_EXPORT_WIDTH = 12800
+const MAX_EXPORT_SCALE = 24
+const MAX_CANVAS_SIDE = 32767
 
-function render() {
-  if (!svgRef.value)
-    return
-  const md = absolutizeMarkdownImages(stripSourceLink(props.markdown || ''))
-  const { root } = transformer.transform(md)
-  if (!mm)
-    mm = Markmap.create(svgRef.value, undefined, root)
-  else
-    mm.setData(root).then(() => mm?.fit())
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob)
+        resolve(blob)
+      else
+        reject(new Error('导出思维导图图片失败'))
+    }, 'image/png')
+  })
 }
 
-onMounted(render)
+function createSvgElement<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+  return document.createElementNS('http://www.w3.org/2000/svg', tag)
+}
+
+function sanitizeSvgForCanvas(svg: SVGSVGElement): SVGSVGElement {
+  const cloned = svg.cloneNode(true) as SVGSVGElement
+
+  cloned.querySelectorAll('image').forEach(el => el.remove())
+  cloned.querySelectorAll('foreignObject').forEach((foreignObject) => {
+    const textContent = foreignObject.textContent?.replace(/\s+/g, ' ').trim()
+    if (!textContent) {
+      foreignObject.remove()
+      return
+    }
+
+    const x = Number(foreignObject.getAttribute('x') || 0)
+    const y = Number(foreignObject.getAttribute('y') || 0)
+    const height = Number(foreignObject.getAttribute('height') || 20)
+    const text = createSvgElement('text')
+    text.setAttribute('x', String(x))
+    text.setAttribute('y', String(y + height / 2))
+    text.setAttribute('dominant-baseline', 'middle')
+    text.setAttribute('font-size', '14')
+    text.setAttribute('font-family', 'Arial, "Microsoft YaHei", sans-serif')
+    text.setAttribute('fill', '#333')
+    text.textContent = textContent
+    foreignObject.replaceWith(text)
+  })
+
+  return cloned
+}
+
+function getExportFontSize(svg: SVGSVGElement): number {
+  const text = svg.querySelector('text, foreignObject')
+  if (!text)
+    return 14
+
+  const fontSize = Number.parseFloat(getComputedStyle(text).fontSize || '')
+  if (Number.isFinite(fontSize) && fontSize > 0)
+    return fontSize
+
+  const attrSize = Number.parseFloat(text.getAttribute('font-size') || '')
+  return Number.isFinite(attrSize) && attrSize > 0 ? attrSize : 14
+}
+
+function stripMindmapNoise(md: string): string {
+  return absolutizeMarkdownImages(stripSourceLink(md || ''))
+    // 笔记里的截图/封面图片在思维导图中会被当作超大 SVG foreignObject，
+    // 容易把导图挤成截图里那种“只剩半框/一条竖线”的效果。导图只保留文字层级。
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/<img\b[^>]*>/gi, '')
+}
+
+async function fit() {
+  await nextTick()
+  requestAnimationFrame(() => mm?.fit())
+}
+
+async function render() {
+  if (!svgRef.value)
+    return
+  const { root } = transformer.transform(stripMindmapNoise(props.markdown))
+  if (!mm)
+    mm = Markmap.create(svgRef.value, { autoFit: true }, root)
+  else
+    await mm.setData(root)
+  await fit()
+}
+
+async function toPngBlob(): Promise<Blob> {
+  await fit()
+  await nextTick()
+  if (!svgRef.value)
+    throw new Error('思维导图尚未渲染完成')
+
+  const svg = svgRef.value
+  const bbox = svg.getBBox()
+  const padding = 48
+  const x = Math.floor(bbox.x - padding)
+  const y = Math.floor(bbox.y - padding)
+  const width = Math.max(Math.ceil(bbox.width + padding * 2), 1)
+  const height = Math.max(Math.ceil(bbox.height + padding * 2), 1)
+  const cloned = sanitizeSvgForCanvas(svg)
+
+  cloned.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+  cloned.setAttribute('width', String(width))
+  cloned.setAttribute('height', String(height))
+  cloned.setAttribute('viewBox', `${x} ${y} ${width} ${height}`)
+  cloned.insertAdjacentHTML('afterbegin', `<rect width="100%" height="100%" fill="#fff"/>`)
+
+  const svgText = new XMLSerializer().serializeToString(cloned)
+  const url = URL.createObjectURL(new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' }))
+
+  try {
+    const img = new Image()
+    img.decoding = 'async'
+    img.src = url
+    await img.decode()
+
+    // 不写死某个导出宽度：按导图内容和文字字号动态反推 PNG 倍率。
+    // 目标是让导出的正文至少有 MIN_EXPORT_FONT_PX 像素高，小图自动放大，
+    // 大图则按内容尺寸导出；同时限制最大边长，避免复杂导图撑爆内存。
+    const fontScale = MIN_EXPORT_FONT_PX / getExportFontSize(svg)
+    const widthScale = MIN_EXPORT_WIDTH / width
+    const rawScale = Math.max(window.devicePixelRatio || 1, fontScale, widthScale)
+    const sideLimitScale = Math.min(MAX_CANVAS_SIDE / width, MAX_CANVAS_SIDE / height)
+    const scale = Math.max(1, Math.min(rawScale, MAX_EXPORT_SCALE, sideLimitScale))
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.ceil(width * scale)
+    canvas.height = Math.ceil(height * scale)
+    const ctx = canvas.getContext('2d')
+    if (!ctx)
+      throw new Error('当前浏览器不支持 Canvas 导出')
+    ctx.fillStyle = '#fff'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.scale(scale, scale)
+    ctx.drawImage(img, 0, 0, width, height)
+    return await canvasToBlob(canvas)
+  }
+  finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+defineExpose({
+  toPngBlob,
+})
+
+onMounted(() => {
+  render()
+  if (wrapRef.value) {
+    resizeObserver = new ResizeObserver(() => fit())
+    resizeObserver.observe(wrapRef.value)
+  }
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  mm?.destroy()
+  mm = null
+})
+
 watch(() => props.markdown, render)
+
 </script>
 
 <template>
-  <div class="w-full h-full bg-white rounded border overflow-hidden">
-    <svg ref="svgRef" class="w-full h-full" />
+  <div ref="wrapRef" class="w-full h-full min-h-[360px] bg-white rounded border overflow-hidden">
+    <svg ref="svgRef" class="w-full h-full min-h-[360px]" />
   </div>
 </template>

--- a/BillNote_extension/src/logic/task-display.ts
+++ b/BillNote_extension/src/logic/task-display.ts
@@ -1,0 +1,21 @@
+import type { TaskRecord } from './types'
+
+const SITE_SUFFIX_RE = /\s*[-_—–|｜]\s*(哔哩哔哩|bilibili|youtube|抖音|douyin|快手|kuaishou)\s*$/i
+
+export function normalizeVideoTitle(title: string | undefined | null): string | undefined {
+  const value = title?.trim()
+  if (!value)
+    return undefined
+  return value
+    .replace(SITE_SUFFIX_RE, '')
+    .trim() || value
+}
+
+export function getTaskDisplayTitle(task: TaskRecord | undefined | null, fallbackTitle?: string): string {
+  if (!task)
+    return normalizeVideoTitle(fallbackTitle) || ''
+  return normalizeVideoTitle((task.result?.audio_meta as { title?: string } | undefined)?.title)
+    || normalizeVideoTitle(task.title)
+    || normalizeVideoTitle(fallbackTitle)
+    || task.videoUrl
+}

--- a/BillNote_extension/src/popup/Popup.vue
+++ b/BillNote_extension/src/popup/Popup.vue
@@ -5,6 +5,7 @@ import { settings, settingsReady, tasks, tasksReady, upsertTask } from '~/logic/
 import { generateNote, getTaskStatus, resolveImageUrl } from '~/logic/api'
 import { fetchBilibiliSubtitle } from '~/logic/bilibili-subtitle'
 import { NOTE_FORMATS, NOTE_STYLES, type NoteFormat, type TaskRecord } from '~/logic/types'
+import { getTaskDisplayTitle, normalizeVideoTitle } from '~/logic/task-display'
 
 const tabUrl = ref<string>('')
 const tabTitle = ref<string>('')
@@ -43,7 +44,7 @@ async function poll(taskId: string) {
       createdAt: activeTask.value?.createdAt ?? Date.now(),
       updatedAt: Date.now(),
       result: res.result ?? activeTask.value?.result,
-      title: activeTask.value?.title,
+      title: activeTask.value?.title || normalizeVideoTitle(tabTitle.value),
     })
     if (res.status !== 'SUCCESS' && res.status !== 'FAILED')
       pollTimer = setTimeout(() => poll(taskId), 3000)
@@ -95,7 +96,7 @@ async function start() {
       message: '已提交',
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      title: tabTitle.value || undefined,
+      title: normalizeVideoTitle(tabTitle.value),
     })
     poll(task_id)
     // 提交后顺手把侧边栏拉起来，免得用户来回切窗口
@@ -144,10 +145,7 @@ function selectTask(id: string) {
 }
 
 const activeCover = computed(() => activeTask.value?.result?.audio_meta?.cover_url as string | undefined)
-const activeTitle = computed(() =>
-  (activeTask.value?.result?.audio_meta?.title as string | undefined)
-  || activeTask.value?.title
-  || tabTitle.value)
+const activeTitle = computed(() => getTaskDisplayTitle(activeTask.value, tabTitle.value))
 
 function fmtTime(ts?: number) {
   if (!ts)
@@ -182,8 +180,8 @@ onUnmounted(() => {
       <button class="text-xs text-gray-500 hover:text-gray-800" @click="openOptions">设置</button>
     </header>
 
-    <div class="text-xs text-gray-500 truncate" :title="tabUrl">
-      {{ tabUrl || '当前没有打开的标签页' }}
+    <div class="text-xs text-gray-500 truncate" :title="normalizeVideoTitle(tabTitle) || tabUrl">
+      {{ normalizeVideoTitle(tabTitle) || tabUrl || '当前没有打开的标签页' }}
     </div>
 
     <div v-if="!supported" class="text-xs text-amber-700 bg-amber-50 p-2 rounded">
@@ -336,8 +334,8 @@ onUnmounted(() => {
           :class="{ 'bg-blue-50': t.taskId === activeTaskId }"
           @click="selectTask(t.taskId)"
         >
-          <span class="truncate flex-1" :title="t.title || t.videoUrl">
-            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.title || t.videoUrl }}
+          <span class="truncate flex-1" :title="getTaskDisplayTitle(t)">
+            {{ getTaskDisplayTitle(t) }}
           </span>
           <span class="text-gray-500 shrink-0">{{ t.status }}</span>
         </li>

--- a/BillNote_extension/src/sidepanel/Sidepanel.vue
+++ b/BillNote_extension/src/sidepanel/Sidepanel.vue
@@ -3,14 +3,17 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { getTaskStatus, resolveImageUrl } from '~/logic/api'
 import { tasks, tasksReady, settingsReady, upsertTask } from '~/logic/storage'
 import type { TaskRecord } from '~/logic/types'
+import { getTaskDisplayTitle } from '~/logic/task-display'
 
 type ViewMode = 'markdown' | 'mindmap' | 'chat'
 
 const activeTaskId = ref<string>('')
 const activeTask = computed<TaskRecord | undefined>(() => tasks.value?.find(t => t.taskId === activeTaskId.value))
 const errorMsg = ref('')
+const successMsg = ref('')
 const viewMode = ref<ViewMode>('markdown')
 const showHistory = ref(false)
+const mindMapRef = ref<{ toPngBlob: () => Promise<Blob> } | null>(null)
 
 const isDone = computed(() => activeTask.value?.status === 'SUCCESS')
 const isFailed = computed(() => activeTask.value?.status === 'FAILED')
@@ -41,7 +44,7 @@ async function poll(taskId: string) {
         message: res.message,
         result: res.result ?? cur.result,
         updatedAt: Date.now(),
-        title: cur.title,
+        title: cur.title || getTaskDisplayTitle(cur),
       })
     }
     if (res.status !== 'SUCCESS' && res.status !== 'FAILED')
@@ -75,11 +78,19 @@ async function copyMarkdown() {
     await navigator.clipboard.writeText(md)
 }
 
+function safeFilename(name: string): string {
+  return (name || 'bilinote')
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || 'bilinote'
+}
+
 function downloadMarkdown() {
   const md = activeTask.value?.result?.markdown
   if (!md)
     return
-  const title = (activeTask.value?.result?.audio_meta as { title?: string } | undefined)?.title || 'bilinote'
+  const title = safeFilename(getTaskDisplayTitle(activeTask.value))
   const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
@@ -89,11 +100,44 @@ function downloadMarkdown() {
   URL.revokeObjectURL(url)
 }
 
-const activeTitle = computed(() =>
-  (activeTask.value?.result?.audio_meta as { title?: string } | undefined)?.title
-  || activeTask.value?.title
-  || activeTask.value?.videoUrl
-  || '')
+async function copyMindMapImage() {
+  try {
+    errorMsg.value = ''
+    successMsg.value = ''
+    const blob = await mindMapRef.value?.toPngBlob()
+    if (!blob)
+      return
+    await navigator.clipboard.write([
+      new ClipboardItem({ [blob.type]: blob }),
+    ])
+    successMsg.value = '思维导图图片已复制'
+    setTimeout(() => { successMsg.value = '' }, 2000)
+  }
+  catch (e) {
+    errorMsg.value = (e as Error).message || '复制思维导图图片失败'
+  }
+}
+
+async function downloadMindMapImage() {
+  try {
+    errorMsg.value = ''
+    successMsg.value = ''
+    const blob = await mindMapRef.value?.toPngBlob()
+    if (!blob)
+      return
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${safeFilename(getTaskDisplayTitle(activeTask.value))}.png`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+  catch (e) {
+    errorMsg.value = (e as Error).message || '下载思维导图图片失败'
+  }
+}
+
+const activeTitle = computed(() => getTaskDisplayTitle(activeTask.value))
 
 const activeCover = computed(() =>
   (activeTask.value?.result?.audio_meta as { cover_url?: string } | undefined)?.cover_url)
@@ -144,8 +188,8 @@ onUnmounted(() => {
           :class="{ 'bg-white border': t.taskId === activeTaskId }"
           @click="selectTask(t.taskId)"
         >
-          <span class="truncate flex-1" :title="t.title || t.videoUrl">
-            {{ (t.result?.audio_meta as { title?: string } | undefined)?.title || t.title || t.videoUrl }}
+          <span class="truncate flex-1" :title="getTaskDisplayTitle(t)">
+            {{ getTaskDisplayTitle(t) }}
           </span>
           <span class="text-gray-400 shrink-0">{{ STAGE_LABELS[t.status] || t.status }}</span>
         </li>
@@ -154,6 +198,9 @@ onUnmounted(() => {
 
     <div v-if="errorMsg" class="text-xs text-red-600 px-3 py-1 break-words bg-red-50 shrink-0">
       {{ errorMsg }}
+    </div>
+    <div v-if="successMsg" class="text-xs text-green-700 px-3 py-1 break-words bg-green-50 shrink-0">
+      {{ successMsg }}
     </div>
 
     <section v-if="!activeTask" class="flex-1 flex items-center justify-center text-gray-400 text-xs px-4 text-center">
@@ -228,6 +275,18 @@ onUnmounted(() => {
           title="下载 .md"
           @click="downloadMarkdown"
         >下载</button>
+        <button
+          v-if="viewMode === 'mindmap'"
+          class="text-gray-500 hover:text-gray-800 px-1.5 py-1 rounded hover:bg-gray-100"
+          title="复制思维导图图片"
+          @click="copyMindMapImage"
+        >复制</button>
+        <button
+          v-if="viewMode === 'mindmap'"
+          class="text-gray-500 hover:text-gray-800 px-1.5 py-1 rounded hover:bg-gray-100"
+          title="下载思维导图 PNG"
+          @click="downloadMindMapImage"
+        >下载</button>
       </div>
 
       <!-- 内容区：占满剩余空间 -->
@@ -240,6 +299,7 @@ onUnmounted(() => {
         />
         <MindMap
           v-else-if="isDone && activeTask.result?.markdown && viewMode === 'mindmap'"
+          ref="mindMapRef"
           :markdown="activeTask.result.markdown"
           class="h-full"
         />

--- a/BillNote_frontend/src/pages/HomePage/components/MarkmapComponent.tsx
+++ b/BillNote_frontend/src/pages/HomePage/components/MarkmapComponent.tsx
@@ -5,6 +5,171 @@ import { Toolbar } from 'markmap-toolbar'
 import 'markmap-toolbar/dist/style.css'
 import JSZip from 'jszip'
 
+const MIN_EXPORT_FONT_PX = 256
+const MIN_EXPORT_WIDTH = 12800
+const WEB_EXPORT_SCALE_FACTOR = 0.34
+const MAX_EXPORT_SCALE = 24
+const MAX_CANVAS_SIDE = 32767
+const MAX_CANVAS_PIXELS = 268000000
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob)
+      } else {
+        reject(new Error('无法创建PNG图片'))
+      }
+    }, 'image/png')
+  })
+}
+
+function createSvgElement<K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] {
+  return document.createElementNS('http://www.w3.org/2000/svg', tag)
+}
+
+function sanitizeSvgForCanvas(svg: SVGSVGElement): SVGSVGElement {
+  const cloned = svg.cloneNode(true) as SVGSVGElement
+
+  // markmap 会在 SVG 的顶层 <g> 上写入当前预览视口的 pan/zoom transform。
+  // 导出时我们按内容 bbox 裁剪，如果保留这个视口 transform，会产生双重偏移，
+  // 导致图片内容跑到角落并留下大片空白。这里只移除顶层视口 transform，
+  // 保留内部节点自身的布局 transform。
+  cloned.querySelector(':scope > g')?.removeAttribute('transform')
+
+  cloned.querySelectorAll('image').forEach(el => el.remove())
+  cloned.querySelectorAll('foreignObject').forEach((foreignObject) => {
+    const textContent = foreignObject.textContent?.replace(/\s+/g, ' ').trim()
+    if (!textContent) {
+      foreignObject.remove()
+      return
+    }
+
+    const x = Number(foreignObject.getAttribute('x') || 0)
+    const y = Number(foreignObject.getAttribute('y') || 0)
+    const height = Number(foreignObject.getAttribute('height') || 20)
+    const text = createSvgElement('text')
+    text.setAttribute('x', String(x))
+    text.setAttribute('y', String(y + height / 2))
+    text.setAttribute('dominant-baseline', 'middle')
+    text.setAttribute('font-size', '14')
+    text.setAttribute('font-family', 'Arial, "Microsoft YaHei", sans-serif')
+    text.setAttribute('fill', '#333')
+    text.textContent = textContent
+    foreignObject.replaceWith(text)
+  })
+
+  return cloned
+}
+
+function getExportFontSize(svg: SVGSVGElement): number {
+  const text = svg.querySelector('text, foreignObject')
+  if (!text) return 14
+
+  const fontSize = Number.parseFloat(getComputedStyle(text).fontSize || '')
+  if (Number.isFinite(fontSize) && fontSize > 0) return fontSize
+
+  const attrSize = Number.parseFloat(text.getAttribute('font-size') || '')
+  return Number.isFinite(attrSize) && attrSize > 0 ? attrSize : 14
+}
+
+function getMindmapBounds(svg: SVGSVGElement) {
+  const target = svg.querySelector('g') || svg
+  const bbox = target.getBBox()
+  const padding = 50
+  return {
+    x: Math.floor(bbox.x - padding),
+    y: Math.floor(bbox.y - padding),
+    width: Math.max(Math.ceil(bbox.width + padding * 2), 1),
+    height: Math.max(Math.ceil(bbox.height + padding * 2), 1),
+  }
+}
+
+function stripMindmapImages(markdown: string) {
+  return (markdown || '')
+    // 思维导图只保留文字结构，图片节点会让预览排版和 PNG 导出效果都很差。
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/<img\b[^>]*>/gi, '')
+}
+
+function transformMindmap(markdown: string) {
+  return transformer.transform(stripMindmapImages(markdown))
+}
+
+function createExportSvg(svgEl: SVGSVGElement) {
+  const bounds = getMindmapBounds(svgEl)
+  const clonedSvg = sanitizeSvgForCanvas(svgEl)
+
+  clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+  clonedSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink')
+  clonedSvg.setAttribute('width', String(bounds.width))
+  clonedSvg.setAttribute('height', String(bounds.height))
+  clonedSvg.setAttribute('viewBox', `${bounds.x} ${bounds.y} ${bounds.width} ${bounds.height}`)
+  clonedSvg.setAttribute('preserveAspectRatio', 'xMidYMid meet')
+
+  const bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+  bgRect.setAttribute('x', String(bounds.x))
+  bgRect.setAttribute('y', String(bounds.y))
+  bgRect.setAttribute('width', String(bounds.width))
+  bgRect.setAttribute('height', String(bounds.height))
+  bgRect.setAttribute('fill', 'white')
+  const firstG = clonedSvg.querySelector('g')
+  clonedSvg.insertBefore(bgRect, firstG || clonedSvg.firstChild)
+
+  return { clonedSvg, ...bounds }
+}
+
+async function exportSvgToPngBlob(svgEl: SVGSVGElement): Promise<Blob> {
+  const { clonedSvg, width, height } = createExportSvg(svgEl)
+  const svgData = new XMLSerializer().serializeToString(clonedSvg)
+  const svgUrl = URL.createObjectURL(new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' }))
+
+  try {
+    const img = new Image()
+    img.decoding = 'async'
+    img.src = svgUrl
+    await img.decode()
+
+    // 按导图内容尺寸和字号动态反推 PNG 倍率，而不是按预览容器或固定倍率导出。
+    const fontScale = MIN_EXPORT_FONT_PX / getExportFontSize(svgEl)
+    const widthScale = MIN_EXPORT_WIDTH / width
+    const rawScale = Math.max(window.devicePixelRatio || 1, fontScale, widthScale)
+    const sideLimitScale = Math.min(MAX_CANVAS_SIDE / width, MAX_CANVAS_SIDE / height)
+    const pixelLimitScale = Math.sqrt(MAX_CANVAS_PIXELS / (width * height))
+    const baseScale = Math.min(rawScale, MAX_EXPORT_SCALE, sideLimitScale, pixelLimitScale)
+    const scale = Math.max(1, baseScale * WEB_EXPORT_SCALE_FACTOR)
+
+    let currentScale = scale
+    let lastError: unknown
+    while (currentScale >= 1) {
+      try {
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.ceil(width * currentScale)
+        canvas.height = Math.ceil(height * currentScale)
+
+        const ctx = canvas.getContext('2d')
+        if (!ctx) {
+          throw new Error('无法获取Canvas上下文')
+        }
+
+        ctx.fillStyle = '#FFFFFF'
+        ctx.fillRect(0, 0, canvas.width, canvas.height)
+        ctx.setTransform(currentScale, 0, 0, currentScale, 0, 0)
+        ctx.drawImage(img, 0, 0, width, height)
+        ctx.setTransform(1, 0, 0, 1, 0, 0)
+
+        return await canvasToBlob(canvas)
+      } catch (error) {
+        lastError = error
+        currentScale = Math.floor(currentScale / 2)
+      }
+    }
+    throw lastError || new Error('导出PNG失败')
+  } finally {
+    URL.revokeObjectURL(svgUrl)
+  }
+}
+
 export interface MarkmapEditorProps {
   /** 要渲染的 Markdown 文本 */
   value: string
@@ -34,6 +199,13 @@ export default function MarkmapEditor({
 
   // 用于跟踪是否处于全屏状态
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [pngAction, setPngAction] = useState<'idle' | 'exporting' | 'copying'>('idle')
+  const [pngMessage, setPngMessage] = useState('')
+
+  const showPngMessage = (message: string) => {
+    setPngMessage(message)
+    window.setTimeout(() => setPngMessage(''), 2500)
+  }
 
   // 监听全屏状态变化
   useEffect(() => {
@@ -64,7 +236,7 @@ export default function MarkmapEditor({
   // 导出HTML思维导图
   const exportHtml = () => {
     try {
-      const { root } = transformer.transform(value)
+      const { root } = transformMindmap(value)
       const data = JSON.stringify(root)
       
       // 创建HTML内容
@@ -202,7 +374,7 @@ export default function MarkmapEditor({
   // 导出XMind格式思维导图
   const exportXMind = async () => {
     try {
-      const { root } = transformer.transform(value);
+      const { root } = transformMindmap(value);
 
       // 生成唯一ID
       const generateId = () => Math.random().toString(36).substring(2, 15);
@@ -311,100 +483,44 @@ export default function MarkmapEditor({
     try {
       if (!svgRef.current || !mmRef.current) return;
 
-      const svgEl = svgRef.current;
-      const mm = mmRef.current;
-
-      // 先调用fit()确保显示完整的思维导图内容
-      await mm.fit();
-      // 等待渲染完成
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      // 获取SVG实际尺寸
-      const svgWidth = svgEl.width.baseVal.value || svgEl.clientWidth || 800;
-      const svgHeight = svgEl.height.baseVal.value || svgEl.clientHeight || 600;
-      
-      // 设置足够大的缩放比例以确保高清输出
-      const scale = 3;
-      
-      // 克隆SVG以避免修改原始SVG
-      const clonedSvg = svgEl.cloneNode(true) as SVGSVGElement;
-      
-      // 设置SVG的背景为白色
-      const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
-      style.textContent = 'svg { background-color: white; }';
-      clonedSvg.insertBefore(style, clonedSvg.firstChild);
-      
-      // 确保SVG有正确的命名空间
-      clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-      clonedSvg.setAttribute('width', svgWidth.toString());
-      clonedSvg.setAttribute('height', svgHeight.toString());
-      
-      // 将SVG转换为Data URI (避免使用Blob URL来解决跨域问题)
-      const svgData = new XMLSerializer().serializeToString(clonedSvg);
-      const svgBase64 = btoa(unescape(encodeURIComponent(svgData)));
-      const dataUri = `data:image/svg+xml;base64,${svgBase64}`;
-      
-      // 创建Canvas
-      const canvas = document.createElement('canvas');
-      canvas.width = svgWidth * scale;
-      canvas.height = svgHeight * scale;
-      
-      // 获取上下文并设置白色背景
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        throw new Error('无法获取Canvas上下文');
-      }
-      
-      // 设置白色背景
-      ctx.fillStyle = '#FFFFFF';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      
-      // 创建Image对象
-      const img = new Image();
-      
-      // 当图片加载完成后，在Canvas上绘制并导出
-      img.onload = () => {
-        try {
-          // 应用缩放
-          ctx.setTransform(scale, 0, 0, scale, 0, 0);
-          
-          // 绘制SVG
-          ctx.drawImage(img, 0, 0);
-          
-          // 重置变换
-          ctx.setTransform(1, 0, 0, 1, 0, 0);
-          
-          // 将Canvas转换为PNG Blob
-          canvas.toBlob((blob) => {
-            if (blob) {
-              // 创建下载链接
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement('a');
-              a.href = url;
-              a.download = `${title || 'mindmap'}.png`;
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-              URL.revokeObjectURL(url);
-            } else {
-              console.error('无法创建Blob对象');
-            }
-          }, 'image/png');
-        } catch (err) {
-          console.error('Canvas处理失败:', err);
-        }
-      };
-      
-      // 设置图片加载错误处理
-      img.onerror = (error) => {
-        console.error('导出PNG失败（图片加载错误）:', error);
-      };
-      
-      // 开始加载SVG图像 (使用Data URI而不是Blob URL)
-      img.src = dataUri;
-      
+      setPngAction('exporting');
+      setPngMessage('正在生成高清 PNG…');
+      const blob = await exportSvgToPngBlob(svgRef.current);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${title || 'mindmap'}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showPngMessage('PNG 已开始下载');
     } catch (error) {
       console.error('导出PNG失败:', error);
+      showPngMessage('导出 PNG 失败，请查看控制台');
+    } finally {
+      setPngAction('idle');
+    }
+  };
+
+  // 复制PNG思维导图
+  const copyPng = async () => {
+    try {
+      if (!svgRef.current || !mmRef.current) return;
+
+      setPngAction('copying');
+      setPngMessage('正在复制高清 PNG…');
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'image/png': exportSvgToPngBlob(svgRef.current),
+        }),
+      ]);
+      showPngMessage('PNG 已复制');
+    } catch (error) {
+      console.error('复制PNG失败:', error);
+      showPngMessage('复制 PNG 失败，请查看控制台');
+    } finally {
+      setPngAction('idle');
     }
   };
 
@@ -428,7 +544,7 @@ export default function MarkmapEditor({
   useEffect(() => {
     const mm = mmRef.current
     if (!mm) return
-    const { root } = transformer.transform(value)
+    const { root } = transformMindmap(value)
     mm.setData(root).then(() => mm.fit())
   }, [value])
 
@@ -459,8 +575,17 @@ export default function MarkmapEditor({
           onClick={exportPng}
           className="rounded p-1 hover:bg-gray-200"
           title="导出PNG图片"
+          disabled={pngAction !== 'idle'}
         >
-          🖼️
+          {pngAction === 'exporting' ? '⏳' : '🖼️'}
+        </button>
+        <button
+          onClick={copyPng}
+          className="rounded p-1 hover:bg-gray-200"
+          title="复制PNG图片"
+          disabled={pngAction !== 'idle'}
+        >
+          {pngAction === 'copying' ? '⏳' : '📋'}
         </button>
         <button
           onClick={exportHtml}
@@ -483,6 +608,11 @@ export default function MarkmapEditor({
           </button>
         )}
       </div>
+      {pngMessage && (
+        <div className="absolute top-11 right-2 z-20 rounded bg-white/95 px-2 py-1 text-xs text-gray-600 shadow">
+          {pngMessage}
+        </div>
+      )}
 
       {/* 如果需要编辑区，就自己加一个 <textarea> 并把 handleChange 绑上 */}
       {/* <textarea value={value} onChange={handleChange} className="mb-2 p-2 border rounded" /> */}


### PR DESCRIPTION
## 改动概述

修复浏览器插件任务列表在生成过程中仍显示视频链接的问题，并完善插件端 / 网页端思维导图的预览、复制和 PNG 导出体验。

这次改动主要解决原项目里两个实际使用痛点：

1. 插件任务在下载中 / 生成中阶段不容易识别具体视频；
2. 思维导图虽然已经生成，但在插件侧边栏里显示不完整，且缺少可用的复制 / 下载高清图片能力。

最终效果是：插件任务从开始处理到生成完成都尽量展示视频标题；思维导图在插件端能完整预览、能复制、能下载高清 PNG；网页端也同步修复 PNG 导出 / 复制，并将导出尺寸校准到接近插件端已验证的清晰度和文件体积。

## 为什么

原项目在这些场景下体验不够完整：

1. **任务生成过程中难以识别视频**
   之前虽然笔记生成完成后能显示视频标题，但下载中 / 生成中阶段仍然显示视频链接。用户如果同时处理多个视频，只看链接很难快速判断每个任务对应哪个视频。

2. **插件端思维导图“生成了但不好用”**
   插件侧边栏和打开笔记页里的思维导图原本容易只显示半框或一条内容，实际阅读价值很低。这个问题不是合理设计，而是 markmap 在插件窄容器、图片节点和尺寸变化场景下没有正确适配。

3. **插件端缺少和笔记页一致的思维导图操作能力**
   笔记页已有复制 / 下载能力，但插件端思维导图没有对应工具栏。用户在插件里看到导图后，还需要能直接复制成图片或下载 PNG，而不是只能看预览。

4. **原有导出不是“可放大查看”的高清图**
   早期按侧边栏当前显示尺寸导出，得到的 PNG 尺寸很小，放大后文字发糊。固定写死宽度也不可靠，因为不同思维导图的宽高和文字大小差异很大。更合理的方式是根据实际内容 bbox 和字体大小反推导出倍率，让导出的文字有足够像素高度。

5. **网页端和插件端导出行为不一致**
   网页端也存在 PNG 下载 / 复制无反应、导出偏移、大面积空白、无处理中提示、导出尺寸过大等问题。尤其同一视频下，插件端导出尺寸已经足够清晰，而网页端会被放大到接近浏览器 canvas 单边上限，导致 PNG 体积明显偏大。

因此这次不是只改一个常数，而是把插件端和网页端的思维导图导出链路整体整理了一遍：先保证能完整预览，再保证能复制 / 下载，再保证导出清晰，最后校准网页端和插件端的尺寸差异。

## 做了什么

### 插件任务标题展示

- 新增 `BillNote_extension/src/logic/task-display.ts`，集中处理任务展示标题。
- Popup、Sidepanel、历史任务列表都统一优先展示：
  1. 后端生成后的 `audio_meta.title`
  2. 浏览器提交任务时抓到的 `tab.title`
  3. 最后才回退到视频链接 / 任务 ID
- 轮询任务状态时保留已有标题，避免下载中 / 生成中阶段又退回显示链接。

### 插件端思维导图预览

- 思维导图渲染前过滤 Markdown 图片 / 截图节点，避免大图把 markmap 布局挤坏。
- 增加容器最小高度和 `ResizeObserver`，侧边栏尺寸变化后自动重新适配。
- 修复插件侧边栏中思维导图只显示半框、内容不完整的问题。

### 插件端思维导图复制 / 下载

- 在插件思维导图视图中新增和笔记页一致的操作：
  - `复制`
  - `下载`
- 复制和下载共用同一套 PNG 导出逻辑。
- 修复直接 canvas 导出时可能出现的 `Tainted canvases may not be exported`：
  - 导出前清理可能污染 canvas 的节点
  - 将 markmap 的 `foreignObject` 转换为纯 SVG 文本
- PNG 导出不再按侧边栏当前显示尺寸，而是按实际 SVG 内容 bbox 导出。
- 根据导图文字字号、内容宽度、最大倍率和 canvas 单边限制动态计算导出倍率，保证导出的文字放大后仍然清晰。

### 网页端思维导图导出 / 复制

- 网页端思维导图预览同样过滤图片，只保留文字结构，避免图片节点影响导图可读性。
- 修复“保存 PNG 点了只恢复默认尺寸但没有下载”的问题：
  - 导出 / 复制不再调用可见导图的 `mm.fit()`
  - 避免导出操作影响当前预览视图
- 新增相邻的复制 PNG 图标按钮，保持原工具栏风格。
- 复制时使用 `ClipboardItem({ 'image/png': Promise<Blob> })`，尽量保留用户点击手势权限。
- PNG 生成失败时支持降低倍率重试。
- 修复导出图片跑到左下角、大面积空白的问题：
  - 导出克隆 SVG 时移除 markmap 顶层 pan / zoom transform
  - 保留内部节点布局 transform
  - 避免 bbox 裁剪和视口 transform 叠加导致双重偏移
- 增加导出 / 复制过程提示：
  - `正在生成高清 PNG…`
  - `正在复制高清 PNG…`
  - `PNG 已开始下载`
  - `PNG 已复制`
  - 按钮处理中临时禁用，避免用户误以为没反应。

### 网页端和插件端导出尺寸校准

- 插件端保留最终调试后认可的高清导出参数：
  - `MIN_EXPORT_FONT_PX = 256`
  - `MIN_EXPORT_WIDTH = 12800`
  - `MAX_EXPORT_SCALE = 24`
  - `MAX_CANVAS_SIDE = 32767`
- 网页端沿用同一套内容 bbox / 字号 / 宽度倍率算法。
- 没有采用简单限制长边，也没有采用固定目标长边。
- 最终在网页端增加 `WEB_EXPORT_SCALE_FACTOR = 0.34`，用于校准网页端和插件端因为 bbox / 字体渲染差异导致的倍率偏差。
- 这样可以让网页端导出尺寸更接近插件端已经验证够用的效果，避免同一导图在网页端被放大到接近 `32767px` 长边，生成过大的 PNG。

## 相比原项目的改进

- 下载中 / 生成中的任务也能尽量显示视频标题，任务列表更容易识别。
- 插件端思维导图从“只显示半框 / 不好阅读”变成可完整预览。
- 插件端补齐复制 / 下载 PNG 能力，和笔记页操作一致。
- 复制 / 下载导出的不再是低分辨率截图，而是根据内容和文字大小动态计算的高清 PNG。
- 网页端 PNG 下载 / 复制从“可能无反应或只重置视图”变成可用操作。
- 网页端导出偏移、大面积空白和无处理中反馈的问题被修复。
- 网页端和插件端导出结果更接近，不再出现网页端明显过大的 PNG。

## 测试方式

- [x] `pnpm typecheck && pnpm build`（浏览器插件）通过
- [x] `npm run build`（Web 前端）通过
- [x] 后端验证不适用：本 PR 不涉及 backend 代码
- [x] 手动验证步骤：
  - 插件任务下载中 / 生成中阶段优先显示视频标题，标题缺失时回退链接。
  - 插件 Sidepanel / Popup / 历史任务列表展示标题逻辑一致。
  - 插件思维导图能完整显示，不再只显示半框。
  - 插件思维导图可复制 PNG、下载 PNG，按钮文案为“复制 / 下载”。
  - 插件导出的 PNG 放大后文字仍可读。
  - 网页端思维导图过滤图片后结构可读。
  - 网页端 PNG 下载和复制按钮可正常工作。
  - 网页端导出的 PNG 不再跑到左下角或出现大面积空白。
  - 网页端导出 / 复制高清 PNG 时有处理中提示。
  - 同一类导图下，网页端导出尺寸不再明显大于插件端。

## 回归风险

影响范围集中在：

- 插件任务标题展示；
- 插件 Sidepanel / Popup / 历史任务列表；
- 插件端思维导图预览、复制和下载；
- 网页端思维导图预览、复制和 PNG 下载。

主要风险：

- 极端复杂、极宽或极高的思维导图仍可能触及浏览器 canvas 尺寸或内存限制；
- 不同浏览器对 Clipboard API / extension 页面 canvas 导出的支持可能存在差异；
- 过滤图片后，思维导图会更偏向文字结构展示，图片内容仍保留在 Markdown 笔记中。

本 PR 不涉及后端接口、数据库、配置或部署流程变更。

## Checklist

- [x] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [x] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [x] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [x] 已自测核心流程
- [x] 已更新相关文档（不适用：本 PR 为插件 / 前端体验修复，不涉及文档）
- [x] 未夹带 secrets / `.env` / 大型二进制
- [x] 单 PR 不跨多个工作区做无关改动
