### PR TITLE
fix(bilibili): 修正分P视频字幕优先链路未传p参数导致取错集

### DIFF
--- a/backend/app/downloaders/bilibili_subtitle.py
+++ b/backend/app/downloaders/bilibili_subtitle.py
@@ -3,12 +3,13 @@
 
 流程：
 1. 从 URL 提 BV id（已有 utils.url_parser.extract_video_id）
-2. GET /x/web-interface/view?bvid=BVxxx → 拿 cid
-3. GET /x/player/wbi/v2?bvid=...&cid=... → 返回 data.subtitle.subtitles[]
+2. 从 URL 提 p 参数（分 P 序号，已有 utils.url_parser.extract_bilibili_p_number）
+3. GET /x/web-interface/view?bvid=BVxxx&p=N → 拿第 N 集的 cid
+4. GET /x/player/wbi/v2?bvid=...&cid=... → 返回 data.subtitle.subtitles[]
    每条带 subtitle_url（B 站后端已经签好 auth_key 的完整地址）
-4. 按优先级（人工 zh-CN > AI zh-CN > 任意 zh > 任意非空）选一条
-5. fetch subtitle_url → JSON {body:[{from,to,content,...}]}
-6. 解析为 TranscriptResult
+5. 按优先级（人工 zh-CN > AI zh-CN > 任意 zh > 任意非空）选一条
+6. fetch subtitle_url → JSON {body:[{from,to,content,...}]}
+7. 解析为 TranscriptResult
 
 AI 字幕需要登录态 cookie（SESSDATA）；通过 CookieConfigManager 注入。
 """
@@ -20,7 +21,7 @@ import requests
 from app.models.transcriber_model import TranscriptResult, TranscriptSegment
 from app.services.cookie_manager import CookieConfigManager
 from app.utils.logger import get_logger
-from app.utils.url_parser import extract_video_id
+from app.utils.url_parser import extract_video_id, extract_bilibili_p_number
 
 logger = get_logger(__name__)
 
@@ -45,10 +46,13 @@ class BilibiliSubtitleFetcher:
             h["Cookie"] = self._cookie
         return h
 
-    def _get_cid(self, bvid: str) -> Optional[int]:
+    def _get_cid(self, bvid: str, p: Optional[int] = None) -> Optional[int]:
         url = "https://api.bilibili.com/x/web-interface/view"
+        params = {"bvid": bvid}
+        if p is not None and p >= 1:
+            params["p"] = p
         try:
-            resp = requests.get(url, params={"bvid": bvid}, headers=self._headers(), timeout=10)
+            resp = requests.get(url, params=params, headers=self._headers(), timeout=10)
             data = resp.json()
         except Exception as e:
             logger.warning(f"获取 cid 失败: {e}")
@@ -56,6 +60,19 @@ class BilibiliSubtitleFetcher:
         if data.get("code") != 0:
             logger.warning(f"view API 返回错误: code={data.get('code')}, msg={data.get('message')}")
             return None
+        # 分 P 视频：data.pages[N-1] 对应第 N 集
+        pages = data.get("data", {}).get("pages", [])
+        if pages:
+            if p is not None and 1 <= p <= len(pages):
+                cid = pages[p - 1].get("cid")
+                logger.info(f"分 P 视频: bvid={bvid} p={p} 共 {len(pages)} 集, 取第 {p} 集 cid={cid}")
+                return int(cid) if cid else None
+            else:
+                # 没有 p 参数或 p 超出范围，取第 1 集
+                cid = pages[0].get("cid")
+                logger.info(f"非分 P 或 p 无效: bvid={bvid} 取第 1 集 cid={cid}")
+                return int(cid) if cid else None
+        # 单集视频
         cid = data.get("data", {}).get("cid")
         return int(cid) if cid else None
 
@@ -114,9 +131,12 @@ class BilibiliSubtitleFetcher:
             logger.info("无法从 URL 提取 BV id")
             return None
 
-        cid = self._get_cid(bvid)
+        # 提取分 P 序号
+        p = extract_bilibili_p_number(video_url)
+
+        cid = self._get_cid(bvid, p)
         if not cid:
-            logger.info(f"{bvid} 没有取到 cid")
+            logger.info(f"{bvid} (p={p}) 没有取到 cid")
             return None
 
         subtitles = self._list_subtitles(bvid, cid)
@@ -149,7 +169,7 @@ class BilibiliSubtitleFetcher:
             return None
 
         full_text = " ".join(s.text for s in segments)
-        logger.info(f"B站直拉字幕成功: {bvid} lan={lan} 共 {len(segments)} 段")
+        logger.info(f"B站直拉字幕成功: {bvid} p={p} lan={lan} 共 {len(segments)} 段")
         return TranscriptResult(
             language=lan,
             full_text=full_text,
@@ -158,6 +178,7 @@ class BilibiliSubtitleFetcher:
                 "source": "bilibili_player_api",
                 "bvid": bvid,
                 "cid": cid,
+                "p": p,
                 "lan": lan,
                 "ai_type": track.get("ai_type"),
             },

--- a/backend/app/utils/url_parser.py
+++ b/backend/app/utils/url_parser.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Tuple
 import requests
 
 
@@ -48,3 +48,34 @@ def resolve_bilibili_short_url(short_url: str) -> Optional[str]:
     except requests.RequestException as e:
         print(f"Error resolving short URL: {e}")
         return None
+
+
+def extract_bilibili_p_number(url: str) -> Optional[int]:
+    """
+    从 B 站分 P 视频 URL 中提取 p 参数（分 P 序号）。
+
+    支持格式：
+      - https://www.bilibili.com/video/BVxxx/?p=36
+      - https://www.bilibili.com/video/BVxxx?p=5
+      - https://b23.tv/xxxxx?p=10
+      - https://www.bilibili.com/video/BVxxx/pN (尾缀形式)
+
+    :param url: B 站视频链接
+    :return: 分 P 序号（从 1 开始），非分 P 视频返回 None
+    """
+    if "b23.tv" in url:
+        url = resolve_bilibili_short_url(url) or url
+
+    # 匹配 ?p=NNN 或 &p=NNN
+    match = re.search(r'[?&]p=(\d+)', url)
+    if match:
+        p = int(match.group(1))
+        if p >= 1:
+            return p
+
+    # 匹配 /pN 尾缀形式（较少见）
+    match = re.search(r'/p(\d+)(?:/?$|\?|&)', url)
+    if match:
+        return int(match.group(1))
+
+    return None


### PR DESCRIPTION
问题：B站分P视频（如62集课程），提交?p=36链接时，
字幕优先链路通过x/web-interface/view API拿cid时未传p参数，
默认取第1集cid，导致生成的是第1集的笔记。
同时yt-dlp正确下载了p36音频，但被跳过。

修复：
- url_parser新增extract_bilibili_p_number()提取URL中的p参数
- bilibili_subtitle的_get_cid()接收p参数，从data.pages[p-1]取对应分P的cid
- fetch_subtitles()调用extract_bilibili_p_number()透传p

## 改动概述

修复 B 站分P视频提交 ?p=N 链接时，字幕优先链路未透传 p 参数，导致始终取第 1 集 cid 生成笔记。

## 为什么

B 站 x/web-interface/view API 默认返回第 1 集的 cid。分P视频（如 62 集课程）用户提交 ?p=36 时，extract_video_id() 只取了 BV 号丢掉了 p 参数，字幕链路用第 1 集的 cid 拉到第 1 集字幕，而 yt-dlp 下载的是正确的 p36 音频——两者对不上，GPT 基于错误的字幕生成笔记。

## 做了什么

- backend/app/utils/url_parser.py: 新增 extract_bilibili_p_number() 从 URL 提取 ?p=N
- backend/app/downloaders/bilibili_subtitle.py: _get_cid() 接收 p 参数，从 data.pages[p-1] 取对应分 P 的 cid；fetch_subtitles() 透传 p

## 测试方式

- [x] python -m py_compile backend/app/utils/url_parser.py 通过
- [x] python -m py_compile backend/app/downloaders/bilibili_subtitle.py 通过
- [x] 手动验证步骤：
  - 提交 https://www.bilibili.com/video/BV19uAfeQEbg/?p=36，检查笔记内容是否为柠檬酸循环（第36集）而非课程规划（第1集）
  - 提交非分P视频链接，确认不受影响
  - 查看日志确认 cid 取自 data.pages[p-1]

## 回归风险

- 非分P视频：无影响，fallback 取 pages[0]
- 分P序号超出范围：fallback 取 pages[0]（第1集）
- 短链接 b23.tv：先 resolve 再提取 p 参数
- 影响面仅限 B 站分P视频的字幕优先路径，不影响 yt-dlp 下载和 Whisper 转写

## Checklist

- [x] 分支命名遵循 [CONTRIBUTING.md §3](../CONTRIBUTING.md#3-分支命名)（`feature/*` / `fix/*` / `release/*` / `hotfix/*`）
- [x] base 分支正确（常规改动 → `develop`；线上紧急 → `master`；发版 → 见 §4.3）
- [x] Commit message 遵循 `type(scope): subject` 格式（[CONTRIBUTING.md §5.1](../CONTRIBUTING.md#51-commit-message-格式)）
- [x] 已自测核心流程
- [ ] 已更新相关文档（`README.md` / `CHANGELOG.md` / `CLAUDE.md` / 模块 README，如适用）
- [x] 未夹带 secrets / `.env` / 大型二进制
- [x] 单 PR 不跨多个工作区做无关改动
