### PR TITLE
fix: nginx default page hijacks port 80 in Docker image

### DIFF
--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -92,6 +92,8 @@ COPY --from=frontend-builder /tmp/frontend/dist /usr/share/nginx/html
 
 # 配置 nginx
 RUN rm -rf /etc/nginx/conf.d/default.conf
+# 删除默认 nginx site，防止 default_server 劫持 80 端口
+RUN rm -f /etc/nginx/sites-enabled/default
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
 # 创建 supervisor 配置
@@ -127,9 +129,8 @@ priority=20
 environment=BACKEND_PORT="%(ENV_BACKEND_PORT)s",BACKEND_HOST="%(ENV_BACKEND_HOST)s",TRANSCRIBER_TYPE="%(ENV_TRANSCRIBER_TYPE)s",WHISPER_MODEL_SIZE="%(ENV_WHISPER_MODEL_SIZE)s",FFMPEG_BIN_PATH="%(ENV_FFMPEG_BIN_PATH)s",HF_ENDPOINT="%(ENV_HF_ENDPOINT)s",STATIC="%(ENV_STATIC)s",OUT_DIR="%(ENV_OUT_DIR)s",DATA_DIR="%(ENV_DATA_DIR)s",NOTE_OUTPUT_DIR="%(ENV_NOTE_OUTPUT_DIR)s",DATABASE_URL="%(ENV_DATABASE_URL)s",IMAGE_BASE_URL="%(ENV_IMAGE_BASE_URL)s",ENV="%(ENV_ENV)s",GROQ_TRANSCRIBER_MODEL="%(ENV_GROQ_TRANSCRIBER_MODEL)s"
 EOF
 
-# 修改 nginx 配置以使用本地 backend
-RUN sed -i 's/proxy_pass http:\/\/backend:8483/proxy_pass http:\/\/127.0.0.1:8483/g' /etc/nginx/conf.d/default.conf && \
-    sed -i 's/proxy_pass http:\/\/frontend:80/proxy_pass http:\/\/127.0.0.1:8080/g' /etc/nginx/conf.d/default.conf
+# 修改 nginx 配置：backend 代理到本地，前端由 nginx 直接服务静态文件
+RUN sed -i 's/proxy_pass http:\/\/backend:8483/proxy_pass http:\/\/127.0.0.1:8483/g' /etc/nginx/conf.d/default.conf
 
 # 启动 supervisor
 # 推荐启动方式（覆盖默认 env）：

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,19 +2,18 @@ server {
   listen 80;
   client_max_body_size 10G;
 
-  # gzip 压缩
   gzip on;
   gzip_vary on;
   gzip_min_length 1024;
   gzip_proxied any;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
-  # 所有非 /api 请求全部代理给 frontend 容器
   location / {
-    proxy_pass http://frontend:80;
+    root /usr/share/nginx/html;
+    index index.html;
+    try_files $uri $uri/ /index.html;
   }
 
-  # 所有 /api 请求代理给 backend 容器
   location /api/ {
     proxy_pass http://backend:8483;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Problem
Running `docker run -p 80:80 ghcr.io/jefferyhcool/bilinote:latest` shows the nginx welcome page instead of BiliNote UI.

## Root Cause
Two issues in `Dockerfile.complete`:

1. **Default nginx site hijacks port 80** — `/etc/nginx/sites-enabled/default` contains `listen 80 default_server` which takes priority over `conf.d/default.conf`
2. **Frontend served via broken proxy** — nginx config proxies `/` to `frontend:80`, and the Dockerfile sed replaces it with `127.0.0.1:8080`, but no service runs on 8080. The frontend is actually built as static files in `/usr/share/nginx/html/`.

## Fix
1. Add `RUN rm -f /etc/nginx/sites-enabled/default` to remove the default site
2. Change `location /` from `proxy_pass http://frontend:80` to serving static files directly with `try_files` (SPA routing support)
3. Remove the frontend proxy sed from Dockerfile (no longer needed)

Closes #405