### PR TITLE
fix(transcriber): 修复 large-v3-turbo 因仓库 404 无法下载 (#402)

### DIFF
--- a/backend/app/transcriber/whisper_models.py
+++ b/backend/app/transcriber/whisper_models.py
@@ -6,7 +6,8 @@
 检测三处，用户想用命名不符合该约定的模型（比如社区微调版、或自己下到本地的模型）就接不上。
 
 本模块把映射**显式化 + 可配置**（对齐 mlx_whisper_transcriber.MLX_MODEL_MAP 的模式）：
-  - 内置：size → Systran/faster-whisper-{size}
+  - 内置：size → faster-whisper 兼容的 CT2 repo_id（多数为 Systran/faster-whisper-{size}；
+    turbo 用社区维护版，见 BUILTIN_WHISPER_MODELS）
   - 自定义：用户在 config/whisper_models.json 登记 {名称: "<repo_id 或本地路径>"}
     （JSON 持久化；Docker 下随 config 卷持久化）
 
@@ -22,7 +23,8 @@ from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# 内置模型：size → faster-whisper 兼容的 HF repo_id（CTranslate2 转换版，Systran 官方维护）。
+# 内置模型：size → faster-whisper 兼容的 HF repo_id（CTranslate2 转换版）。
+# 多数档位用 Systran 官方维护的转换版；turbo 例外见下。
 BUILTIN_WHISPER_MODELS: Dict[str, str] = {
     "tiny": "Systran/faster-whisper-tiny",
     "base": "Systran/faster-whisper-base",
@@ -31,7 +33,10 @@ BUILTIN_WHISPER_MODELS: Dict[str, str] = {
     "large-v1": "Systran/faster-whisper-large-v1",
     "large-v2": "Systran/faster-whisper-large-v2",
     "large-v3": "Systran/faster-whisper-large-v3",
-    "large-v3-turbo": "Systran/faster-whisper-large-v3-turbo",
+    # issue #402：Systran 没有 turbo 的 CT2 转换版（Systran/faster-whisper-large-v3-turbo
+    # 在 HF 上 401/404），点下载会静默失败、状态一直「未下载」。改用社区维护的 CT2 转换版
+    # （deepdml，直链可达、含 model.bin，与 faster-whisper 的 large-v3-turbo 等价）。
+    "large-v3-turbo": "deepdml/faster-whisper-large-v3-turbo-ct2",
 }
 
 # 前端下拉默认展示的内置档位（保持与历史 WHISPER_MODEL_SIZES 一致，不把 8 个全列出来）

--- a/backend/tests/test_whisper_models.py
+++ b/backend/tests/test_whisper_models.py
@@ -50,7 +50,19 @@ class TestResolve(unittest.TestCase):
 
     def test_builtin_resolves_to_systran(self):
         self.assertEqual(self.reg.resolve("tiny"), "Systran/faster-whisper-tiny")
-        self.assertEqual(self.reg.resolve("large-v3-turbo"), "Systran/faster-whisper-large-v3-turbo")
+
+    def test_large_v3_turbo_resolves_to_live_repo(self):
+        # 回归 issue #402：Systran 从未发布 turbo 的 CT2 转换版，
+        # 原映射 Systran/faster-whisper-large-v3-turbo 在 HF 上 401/404，
+        # 导致下载静默失败、状态一直「未下载」。改用社区维护的 CT2 转换版。
+        self.assertEqual(
+            self.reg.resolve("large-v3-turbo"),
+            "deepdml/faster-whisper-large-v3-turbo-ct2",
+        )
+        self.assertNotEqual(
+            self.reg.resolve("large-v3-turbo"),
+            "Systran/faster-whisper-large-v3-turbo",
+        )
 
     def test_passthrough_repo_id(self):
         # 用户直接把 HF repo_id 当 model_size 传进来（含 "/"）


### PR DESCRIPTION
## 问题

Issue #402：在「音频转写设置」点击 `large-v3-turbo` 的下载按钮后，无进度转圈、状态一直显示「未下载」、前端也没有任何错误提示。

## 根因

内置映射 `large-v3-turbo` → `Systran/faster-whisper-large-v3-turbo`，但该仓库已从 HuggingFace 下架：

```
GET https://huggingface.co/api/models/Systran/faster-whisper-large-v3-turbo → 401 (Repository Not Found)
```

下载在后台执行，`snapshot_download` 立即抛错被 `_do_download_whisper` 吞掉并把 `_downloading` 置为 `failed`；但 `/transcriber_models_status` 只回传 `downloading` / `downloaded` 两个布尔，`failed` 状态被丢弃 —— 于是前端表现为「点了没反应、永远未下载、也不报错」。这与 issue 评论里 AdySnowflake 抓到的后端日志一致。

## 修改

`large-v3-turbo` 改指向社区维护的 CT2 转换版 **`deepdml/faster-whisper-large-v3-turbo-ct2`**：

- HF API 直链可达（`200`，**无重定向** → 保证 `snapshot_download` 落盘目录名与 `_check_whisper_model_exists` 的存在性检测一致，不会出现「下好了仍显示未下载」）；
- 含 `model.bin` / `config.json` / `tokenizer.json` / `preprocessor_config.json` / `vocabulary.json`，恰好覆盖下载器的 `allow_patterns`；
- 与 faster-whisper 的 `large-v3-turbo` 等价（faster-whisper 1.1.1 内置映射的 `mobiuslabsgmbh` 仓库已 307 跳转到第三方 `dropbox-dash`，重定向会带来缓存目录名歧义，故选直链 200 的 deepdml）。

其余档位（tiny~large-v3）仍用 Systran 官方转换版，经校验均存活；MLX 路径的 `mlx-community/whisper-large-v3-turbo` 也仍存活，无需改动。

## 测试

新增回归测试 `test_large_v3_turbo_resolves_to_live_repo`，断言解析结果为存活仓库、且不再是已失效的 Systran 仓库。

```
$ pytest tests/test_whisper_models.py -q
14 passed
```

> 备注（非本 PR 范围）：`/transcriber_models_status` 目前不回传 `failed` 状态，任何下载失败（网络等）都会静默。可作为后续改进，把失败态透出到前端以便给出错误提示。

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)