### PR TITLE
fix(frontend): 视频链接缺协议头时自动补 https:// 而非直接拒绝

### DIFF
--- a/BillNote_frontend/src/pages/HomePage/components/NoteForm.tsx
+++ b/BillNote_frontend/src/pages/HomePage/components/NoteForm.tsx
@@ -42,6 +42,9 @@ import { useNavigate } from 'react-router-dom'
 import toast from 'react-hot-toast'
 
 /* -------------------- 校验 Schema -------------------- */
+/** 用户粘贴的链接常缺协议头（如 bilibili.com/...），无任何 scheme 时自动补 https:// */
+const withScheme = (url: string) => (/^[a-z][a-z0-9+.-]*:\/\//i.test(url) ? url : `https://${url}`)
+
 const formSchema = z
   .object({
     video_url: z.string().optional(),
@@ -72,7 +75,7 @@ const formSchema = z
       }
       else {
         try {
-          const url = new URL(video_url)
+          const url = new URL(withScheme(video_url))
           if (!['http:', 'https:'].includes(url.protocol))
             throw new Error()
         }
@@ -221,6 +224,8 @@ const NoteForm = () => {
     console.log('Not even go here')
     const payload: NoteFormValues = {
       ...values,
+      video_url:
+        values.platform === 'local' ? values.video_url : withScheme(values.video_url || ''),
       provider_id: modelList.find(m => m.model_name === values.model_name)!.provider_id,
       task_id: currentTaskId || '',
     }


### PR DESCRIPTION
## 问题

用户粘贴的视频链接如果没有协议头（例如 `bilibili.com/list/watchlater/?bvid=BV...` 或 `www.bilibili.com/video/BV...`），前端表单校验中的 `new URL(video_url)` 会抛异常，直接提示"请输入正确的视频链接"。从聊天记录、笔记等处摘抄的链接经常缺协议头，这类输入其实意图明确。

## 修复

新增 `withScheme()` 辅助函数：输入不含任何 scheme（`^[a-z][a-z0-9+.-]*://`）时自动补 `https://`。

- **校验时**：`new URL(withScheme(video_url))`，无协议头的合法链接可通过校验
- **提交时**：payload 中的 `video_url` 同样补全后再发给后端（`platform === 'local'` 的本地路径不处理）
- 已带明确 scheme 的输入原样保留，`ftp://` 等非 http(s) 协议仍按原逻辑拒绝

改动仅 `NoteForm.tsx` 一个文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)