### PR TITLE
fix(youtube): 修复 YouTube 笔记生成失败 "Requested format is not available"

### DIFF
--- a/backend/app/downloaders/bilibili_dm_patch.py
+++ b/backend/app/downloaders/bilibili_dm_patch.py
@@ -58,12 +58,15 @@ def apply_bilibili_dm_img_patch() -> bool:
     if getattr(original, '_bili_dm_patched', False):
         return True
 
-    def _patched_download_playinfo(self, bvid, cid, headers=None, query=None):
+    def _patched_download_playinfo(self, bvid, cid, headers=None, query=None, **kwargs):
         # dm_* are merged into the query that the original method signs via
         # _sign_wbi; caller-supplied query params (e.g. try_look/qn) take
         # precedence over the injected dummies.
+        # **kwargs stays open on purpose: yt-dlp keeps adding parameters to
+        # _download_playinfo (2026.x added `fatal`), and a wrapper that pins the
+        # signature turns every such addition into a TypeError at download time.
         merged_query = {**build_dm_img_params(), **(query or {})}
-        return original(self, bvid, cid, headers=headers, query=merged_query)
+        return original(self, bvid, cid, headers=headers, query=merged_query, **kwargs)
 
     _patched_download_playinfo._bili_dm_patched = True
     BilibiliBaseIE._download_playinfo = _patched_download_playinfo

--- a/backend/app/downloaders/youtube_downloader.py
+++ b/backend/app/downloaders/youtube_downloader.py
@@ -55,6 +55,10 @@ class YoutubeDownloader(Downloader, ABC):
 
         if skip_download:
             ydl_opts['skip_download'] = True
+            # 只取元信息时并不需要媒体流。yt-dlp 版本落后于 YouTube player 时，
+            # nsig 解析失败会导致所有音视频格式被丢弃，此时格式选择会抛
+            # "Requested format is not available"，把一个已经拿到字幕的任务带崩。
+            ydl_opts['ignore_no_formats_error'] = True
 
         _apply_proxy(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -63,7 +67,8 @@ class YoutubeDownloader(Downloader, ABC):
             title = info.get("title")
             duration = info.get("duration", 0)
             cover_url = info.get("thumbnail")
-            ext = info.get("ext", "m4a")
+            # skip_download 时 yt-dlp 返回 ext=None，默认值不会生效，避免拼出 "xxx.None"
+            ext = info.get("ext") or "m4a"
             audio_path = os.path.join(output_dir, f"{video_id}.{ext}")
 
         return AudioDownloadResult(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -125,5 +125,5 @@ webencodings==0.5.1
 websockets==15.0.1
 yarl==1.19.0
 youtube-transcript-api>=1.0.0
-yt-dlp==2025.3.31
+yt-dlp>=2026.7.4
 zopfli==0.2.3.post1

--- a/backend/tests/test_bilibili_dm_patch.py
+++ b/backend/tests/test_bilibili_dm_patch.py
@@ -71,7 +71,9 @@ class ApplyPatchTest(unittest.TestCase):
 
         def fake_download_json(url, video_id, **kwargs):
             # Avoid any network; the real playurl call would 412 without dm_*.
-            return {"data": {"ok": True}}
+            # yt-dlp >= 2026.x checks the envelope's `code` before returning
+            # `data`, so the fake has to look like a real playurl response.
+            return {"code": 0, "data": {"ok": True}}
 
         ie = BilibiliBaseIE(YoutubeDL({"quiet": True}))
         ie._sign_wbi = fake_sign_wbi
@@ -88,6 +90,32 @@ class ApplyPatchTest(unittest.TestCase):
         self.assertEqual(captured["qn"], 64)
         # the original method still builds its base params
         self.assertEqual(captured["bvid"], "BV1X9L16oEgB")
+
+    def test_patch_forwards_unknown_kwargs_to_original(self):
+        """
+        yt-dlp's real call site passes kwargs the wrapper never declared —
+        `_real_extract` calls `_download_playinfo(..., fatal=False)` since
+        2026.x. A wrapper with a pinned signature raises TypeError there and
+        breaks every Bilibili download, so unknown kwargs must pass through.
+        """
+        from yt_dlp import YoutubeDL
+        from yt_dlp.extractor.bilibili import BilibiliBaseIE
+
+        bilibili_dm_patch.apply_bilibili_dm_img_patch()
+
+        seen = {}
+
+        def fake_download_json(url, video_id, **kwargs):
+            return {"code": 0, "data": {"ok": True}}
+
+        ie = BilibiliBaseIE(YoutubeDL({"quiet": True}))
+        ie._sign_wbi = lambda params, video_id: seen.update(params) or params
+        ie._download_json = fake_download_json
+
+        # Must not raise TypeError on a kwarg the wrapper does not name.
+        ie._download_playinfo("BV1X9L16oEgB", 4242, headers={}, query={}, fatal=False)
+
+        self.assertTrue(REQUIRED_KEYS.issubset(seen.keys()))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_youtube_metadata_only.py
+++ b/backend/tests/test_youtube_metadata_only.py
@@ -52,7 +52,12 @@ def _load_youtube_downloader():
     _stub("app.models")
     _stub("app.services")
     _stub("app.utils")
-    _stub("app.downloaders.base", Downloader=_Downloader, DownloadQuality=str)
+    _stub(
+        "app.downloaders.base",
+        Downloader=_Downloader,
+        DownloadQuality=str,
+        YDL_RETRY_OPTS={"retries": 3, "fragment_retries": 3, "socket_timeout": 30},
+    )
     _stub("app.downloaders.youtube_subtitle", YouTubeSubtitleFetcher=object)
     _stub("app.models.notes_model", AudioDownloadResult=_AudioDownloadResult)
     _stub("app.models.transcriber_model", TranscriptResult=object)

--- a/backend/tests/test_youtube_metadata_only.py
+++ b/backend/tests/test_youtube_metadata_only.py
@@ -1,0 +1,146 @@
+"""
+Coverage for the YouTube "metadata only" download path.
+
+Background: when a YouTube video already has subtitles, NoteGenerator skips the
+audio download and calls `YoutubeDownloader.download(skip_download=True)` purely
+to read title/duration/cover. That call used to still request
+`format='bestaudio[ext=m4a]/bestaudio/best'`.
+
+Whenever the installed yt-dlp lags behind YouTube's player, nsig extraction
+fails, every audio/video format is dropped (only storyboard images remain) and
+format selection raises "Requested format is not available" — killing a task
+whose transcript had already been fetched successfully.
+
+These tests pin the two guarantees of that path:
+  1. skip_download implies ignore_no_formats_error, so a formatless extraction
+     degrades to "no audio" instead of failing the whole note.
+  2. ext falls back to m4a, since yt-dlp reports ext=None when skipping the
+     download (dict.get's default does not fire on an explicit None).
+"""
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "app" / "downloaders" / "youtube_downloader.py"
+
+
+def _stub(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules.setdefault(name, module)
+    return module
+
+
+class _Downloader:
+    def __init__(self):
+        self.cache_data = "/tmp"
+
+
+class _AudioDownloadResult:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _load_youtube_downloader():
+    """Load the module with its app-level dependencies stubbed out."""
+    _stub("app")
+    _stub("app.downloaders")
+    _stub("app.models")
+    _stub("app.services")
+    _stub("app.utils")
+    _stub("app.downloaders.base", Downloader=_Downloader, DownloadQuality=str)
+    _stub("app.downloaders.youtube_subtitle", YouTubeSubtitleFetcher=object)
+    _stub("app.models.notes_model", AudioDownloadResult=_AudioDownloadResult)
+    _stub("app.models.transcriber_model", TranscriptResult=object)
+    _stub(
+        "app.services.proxy_config_manager",
+        ProxyConfigManager=type(
+            "ProxyConfigManager", (), {"get_proxy_url": lambda self: None}
+        ),
+    )
+    _stub("app.utils.path_helper", get_data_dir=lambda: "/tmp")
+    _stub("app.utils.url_parser", extract_video_id=lambda url, platform: "vid")
+
+    spec = importlib.util.spec_from_file_location("youtube_downloader", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError("youtube_downloader module spec not found")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeYoutubeDL:
+    """Records the opts it was constructed with; mimics a formatless extraction."""
+
+    captured_opts = None
+
+    def __init__(self, opts):
+        type(self).captured_opts = opts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def extract_info(self, url, download=True):
+        # What yt-dlp yields for a metadata-only extraction: no media, so no ext.
+        return {
+            "id": "CJ4ndXv3CkY",
+            "title": "example",
+            "duration": 2231,
+            "thumbnail": "https://example.invalid/t.jpg",
+            "ext": None,
+            "tags": [],
+        }
+
+
+class YoutubeMetadataOnlyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.module = _load_youtube_downloader()
+        except Exception as exc:  # pragma: no cover - env without yt-dlp
+            raise unittest.SkipTest(f"youtube_downloader not importable: {exc}")
+
+    def setUp(self):
+        self._real_ydl = self.module.yt_dlp.YoutubeDL
+        self.module.yt_dlp.YoutubeDL = _FakeYoutubeDL
+        _FakeYoutubeDL.captured_opts = None
+
+    def tearDown(self):
+        self.module.yt_dlp.YoutubeDL = self._real_ydl
+
+    def test_skip_download_tolerates_missing_formats(self):
+        self.module.YoutubeDownloader().download(
+            "https://www.youtube.com/watch?v=CJ4ndXv3CkY",
+            output_dir="/tmp",
+            skip_download=True,
+        )
+        self.assertTrue(_FakeYoutubeDL.captured_opts.get("ignore_no_formats_error"))
+
+    def test_missing_ext_falls_back_to_m4a(self):
+        result = self.module.YoutubeDownloader().download(
+            "https://www.youtube.com/watch?v=CJ4ndXv3CkY",
+            output_dir="/tmp",
+            skip_download=True,
+        )
+        self.assertTrue(result.file_path.endswith(".m4a"), result.file_path)
+        self.assertNotIn("None", result.file_path)
+
+    def test_full_download_still_selects_an_audio_format(self):
+        self.module.YoutubeDownloader().download(
+            "https://www.youtube.com/watch?v=CJ4ndXv3CkY",
+            output_dir="/tmp",
+        )
+        opts = _FakeYoutubeDL.captured_opts
+        self.assertIn("bestaudio", opts.get("format", ""))
+        self.assertNotIn("ignore_no_formats_error", opts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

输入 YouTube 链接生成笔记时任务必定失败：

```
ERROR: [youtube] <id>: Requested format is not available. Use --list-formats for a list of available formats
```

即使字幕已经抓取成功（日志里能看到 `成功获取 YouTube 字幕，共 1021 段`），任务仍然在下载阶段崩掉，最终 `TaskStatus.FAILED`。

## 原因

两个独立的问题叠在一起：

**1. `yt-dlp` 被钉在 `2025.3.31`（`backend/requirements.txt`）**

YouTube 之后轮换过 player，该版本解不出 nsig 签名，所有音视频格式被丢弃，只剩 storyboard 图片：

```
WARNING: [youtube] nsig extraction failed: Some formats may be missing
WARNING: Only images are available for download. use --list-formats to see them
ERROR: [youtube] Requested format is not available
```

**2. "只取元信息"的路径却要求选出音频格式**

有字幕时 `NoteGenerator` 不下载音视频，只调 `download(skip_download=True)` 拿 title/duration/cover。但 `YoutubeDownloader.download` 无条件设置了 `format='bestaudio[ext=m4a]/bestaudio/best'`，导致一个根本不需要媒体流的调用也会因选不出格式而抛错——把一个字幕已经到手的任务整个带崩，随后回退到"完整下载"再挂一次。

第 2 点是放大器：只修 yt-dlp 版本的话，下次 YouTube 再变、yt-dlp 再落后时，同样的全量失败会重演；修掉之后，有字幕的视频会降级为"没有音频"而不是任务失败。

## 改动

| 文件 | 改动 |
|---|---|
| `youtube_downloader.py` | `skip_download` 时设 `ignore_no_formats_error=True` |
| `youtube_downloader.py` | `ext = info.get("ext") or "m4a"`：跳过下载时 yt-dlp 返回 `ext=None`，`dict.get` 的默认值对显式 `None` 不生效，会拼出 `xxx.None` |
| `requirements.txt` | `yt-dlp==2025.3.31` → `>=2026.7.4` |
| `bilibili_dm_patch.py` | wrapper 透传 `**kwargs`（见下） |
| `tests/` | 新增 YouTube 元信息路径测试；补充 B 站 kwargs 透传测试 |

### 关于 `yt-dlp` 用 `>=` 而不是 `==`

yt-dlp 是对抗 YouTube 持续变化的滚动依赖，**精确钉版本本身就是这个 bug 的成因**——钉到 `==2026.7.4` 只是把同一个定时器重置一遍。同文件的 `youtube-transcript-api>=1.0.0` 已有先例。如果维护者倾向保持 `==`，我可以改。

### ⚠️ 升级 yt-dlp 会连带打断 B 站（本 PR 一并修了）

这点值得单独说明。升级后 yt-dlp 的 `_real_extract` 会以 `fatal=False` 调用 `_download_playinfo`，而 `bilibili_dm_patch.py` 的 wrapper 钉死了签名，于是**所有 B 站下载**都会抛：

```
TypeError: _patched_download_playinfo() got an unexpected keyword argument 'fatal'
```

wrapper 已改为透传 `**kwargs`，对新旧 yt-dlp 都成立。顺带一提：yt-dlp 2026.x 已经在 `_download_playinfo` 里原生注入 `self._dm_params`，这个 monkey-patch 现在是冗余的——但本 PR 不动它，那是另一件事，需要单独验证。

## 验证

真实环境跑通（Docker，`fast-whisper` + DeepSeek）：

- **YouTube**（有字幕 → 元信息路径）：原本必失败的链接现在正常出笔记
- **B 站**（无字幕 → 完整下载 + 转写）：正常出笔记
- 真实音频下载单独验证过（format 140 m4a），确认无字幕的 YouTube 视频也能走通

```
pytest tests/  →  46 passed, 3 skipped, 1 failed
```

唯一失败的 `test_task_serial_executor::test_executor_runs_tasks_one_by_one` 在升级前后表现完全一致（我在 `yt-dlp==2025.3.31` 的干净容器里复现过），与本次改动无关，因此未作改动。

新增测试均确认过 red-green：在未修复的代码上会失败，且 B 站那条复现的正是上面production 里的 `TypeError`。
