### PR TITLE
fix(deps): bump requests to 2.32.4

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -95,7 +95,7 @@ pytz==2025.2
 pywin32-ctypes==0.2.3
 PyYAML==6.0.2
 redis==5.2.1
-requests==2.32.3
+requests==2.32.4
 rich==14.0.0
 rich-toolkit==0.14.1
 shellingham==1.5.4


### PR DESCRIPTION
## Summary

Bumps `requests` from 2.32.3 to 2.32.4 in `backend/requirements.txt`.

## Vulnerability addressed

- **GHSA-9hjg-9r4m-mvj7** (CVE-2024-47081) — `.netrc` credentials leak via malicious URLs in requests < 2.32.4. Severity: MODERATE.

Relates to #395.

## Scanner evidence

- **Before patch (2.32.3):** osv-scanner reported `PYSEC-2026-1872` / `GHSA-9hjg-9r4m-mvj7` for `requests==2.32.3`.
- **After patch (2.32.4):** `PYSEC-2026-1872` / `GHSA-9hjg-9r4m-mvj7` is no longer reported.

**Remaining advisory:** `PYSEC-2026-2275` (CVE-2026-25645, GHSA-gc5v-m9x4-r6x2) still affects `requests==2.32.4` — fixed in 2.33.0. A separate bump may be needed.

## Changed files

- `backend/requirements.txt` (1 line: `requests==2.32.3` → `requests==2.32.4`)

No application logic or source behavior changed.