### PR TITLE
fix(deps): bump requests to 2.33.0 (PYSEC-2026-2275)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -95,7 +95,7 @@ pytz==2025.2
 pywin32-ctypes==0.2.3
 PyYAML==6.0.2
 redis==5.2.1
-requests==2.32.4
+requests==2.33.0
 rich==14.0.0
 rich-toolkit==0.14.1
 shellingham==1.5.4


### PR DESCRIPTION
Updates `requests` to address PYSEC-2026-2275 (GHSA-gc5v-m9x4-r6x2).

Evidence:
- `backend/requirements.txt` pinned `requests==2.32.4`
- `pip-audit -r` reported PYSEC-2026-2275 on 2.32.4 before the update
- updated version: `2.33.0`

Validation:
- `pip-audit -r` no longer reports PYSEC-2026-2275 on 2.33.0 (No known vulnerabilities found)
- `python -m pytest tests/test_note_helper.py tests/test_proxy_apply_env.py tests/test_request_chunker.py` passes (10 passed), run in a venv with requests==2.33.0

Scope: dependency/lockfile update only.
